### PR TITLE
jaq requires rust >= 1.59

### DIFF
--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -9,6 +9,7 @@ description = "Just another JSON query tool"
 repository = "https://github.com/01mf02/jaq"
 keywords = ["json", "query", "jq"]
 categories = ["command-line-utilities", "compilers", "parser-implementations"]
+rust-version = "1.59"
 
 [dependencies]
 jaq-core = { version = "0.6", path = "../jaq-core" }


### PR DESCRIPTION
https://github.com/01mf02/jaq/blob/main/jaq/src/main.rs#L249