### PR TITLE
Allow trailing comma in object literal

### DIFF
--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -101,6 +101,11 @@ fn object() {
         [json!({"a": 1}), json!({"b": 1})],
     );
     give(
+        json!(null),
+        "{a:1, b:2, c:3,}",
+        json!({"a": 1, "b": 2, "c": 3}),
+    );
+    give(
         json!("c"),
         r#"{a: 1, "b": 2, (.): 3}"#,
         json!({"a": 1, "b": 2, "c": 3}),
@@ -110,6 +115,7 @@ fn object() {
         "{a, c: 3}",
         json!({"a": 1, "c": 3}),
     );
+    give(json!({"a": 1, "b": 2}), "{a,}", json!({"a": 1}));
 }
 
 #[test]

--- a/jaq-parse/src/filter.rs
+++ b/jaq-parse/src/filter.rs
@@ -243,6 +243,7 @@ where
     let object = key_str
         .or(key_filter)
         .separated_by(just(Token::Ctrl(',')))
+        .allow_trailing()
         .delimited_by(just(Token::Ctrl('{')), just(Token::Ctrl('}')))
         .collect();
 


### PR DESCRIPTION
This PR allows to use trailing comma in object literal, just like jq supports.
```
 $ jq -n '{a:1,}'
{
  "a": 1
}

 $ jaq -n '{a:1,}'
Error: Unexpected token while parsing object key, expected (
   ╭─[<unknown>:1:6]
   │
 1 │ {a:1,}
   ·      ┬
   ·      ╰── Unexpected token }
───╯

 $ cargo run -- -n '{a:1,}' 2>/dev/null
{
  "a": 1
}
```