### PR TITLE
Fix --join-output (-j) to output raw strings

### DIFF
--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -299,7 +299,7 @@ fn run_and_print(
 
     let last = run(filter, ctx, iter, |output| {
         match output {
-            Val::Str(s) if cli.raw_output => print!("{}", s),
+            Val::Str(s) if cli.raw_output || cli.join_output => print!("{}", s),
             _ => {
                 // this looks ugly, but it is hard to abstract over the `Formatter` because
                 // we cannot create a `Box<dyn Formatter>` because


### PR DESCRIPTION
This PR fixes `--join-output (-j)` option to behave more compatible with jq, to emit strings in raw mode.
```
 $ jq -n -j 'null,true,"hello, world",42,[]' 
nulltruehello, world42[]

 $ jaq -n -j 'null,true,"hello, world",42,[]' 
nulltrue"hello, world"42[]
```