### PR TITLE
Add while to standard library

### DIFF
--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -52,6 +52,7 @@ def range(x): range(0; x);
 def repeat(g): [g] | recurse(.) | .[];
 def recurse: recurse(.[]?);
 def recurse(f; cond): recurse(f | select(cond));
+def while(cond; update): recurse(if cond then update else empty end; cond);
 
 # Iterators
 def map(f): [.[] | f];

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -212,3 +212,10 @@ fn typ() {
     give(json!(true), "type", json!("boolean"));
     give(json!(null), "type", json!("null"));
 }
+
+#[test]
+fn while_() {
+    give(json!(1), "[while(. < 100; . * 2)]", json!([1,2,4,8,16,32,64]));
+    give(json!("a"), "[while(length < 4; . + \"a\")]", json!(["a", "aa", "aaa"]));
+    give(json!([1,2,3]), "[while(length > 0; .[1:])]", json!([[1,2,3],[2,3],[3]]));
+}


### PR DESCRIPTION
This adds the `while` command from jq's standard library.

```
$ ./target/debug/jaq '[ while(. < 100; . * 2) ]' <<< 1
[
  1,
  2,
  4,
  8,
  16,
  32,
  64
]
```