### PR TITLE
Make Filter struct Clone

### DIFF
--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -100,7 +100,7 @@ impl<'i> Ctx<'i> {
 }
 
 /// Function from a value to a stream of value results.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Filter(crate::filter::Filter);
 
 impl Filter {


### PR DESCRIPTION
Hey! I'm planning on using `jaq_core` to have embedded JQ-style syntax in my widget system [eww](https://github.com/elkowar/eww).
As the filters are gonna be ran several times, I'd want to cache the generated filters in between runs. For this, the filter struct needs to be clone!