### PR TITLE
Custom filters

### DIFF
--- a/jaq-core/src/error.rs
+++ b/jaq-core/src/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
     Regex(String),
     /// `"a" | test("."; "b")`
     RegexFlag(char),
+    /// custom filter without update
+    NonUpdatable,
 }
 
 impl fmt::Display for Error {
@@ -77,6 +79,7 @@ impl fmt::Display for Error {
             Self::PathExp => write!(f, "invalid path expression"),
             Self::Regex(e) => write!(f, "invalid regex: {e}"),
             Self::RegexFlag(c) => write!(f, "invalid regex flag '{c}'"),
+            Self::NonUpdatable => write!(f, "custom filter doesn't implement update"),
         }
     }
 }

--- a/jaq-core/src/error.rs
+++ b/jaq-core/src/error.rs
@@ -52,6 +52,8 @@ pub enum Error {
     RegexFlag(char),
     /// custom filter without update
     NonUpdatable,
+    /// when no value is where one is expected
+    NoValue,
 }
 
 impl fmt::Display for Error {
@@ -80,6 +82,7 @@ impl fmt::Display for Error {
             Self::Regex(e) => write!(f, "invalid regex: {e}"),
             Self::RegexFlag(c) => write!(f, "invalid regex flag '{c}'"),
             Self::NonUpdatable => write!(f, "custom filter doesn't implement update"),
+            Self::NoValue => write!(f, "no value but one was expected"),
         }
     }
 }

--- a/jaq-core/src/error.rs
+++ b/jaq-core/src/error.rs
@@ -52,8 +52,8 @@ pub enum Error {
     RegexFlag(char),
     /// custom filter without update
     NonUpdatable,
-    /// when no value is where one is expected
-    NoValue,
+    /// arbitrary errors for custom filters
+    Custom(String),
 }
 
 impl fmt::Display for Error {
@@ -82,7 +82,7 @@ impl fmt::Display for Error {
             Self::Regex(e) => write!(f, "invalid regex: {e}"),
             Self::RegexFlag(c) => write!(f, "invalid regex flag '{c}'"),
             Self::NonUpdatable => write!(f, "custom filter doesn't implement update"),
-            Self::NoValue => write!(f, "no value but one was expected"),
+            Self::Custom(e) => write!(f, "custom filter error: {e}"),
         }
     }
 }

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -384,7 +384,7 @@ impl Filter {
     /// `p.update(cv, f)` returns the output of `v | p |= f`
     fn update<'a>(&'a self, cv: Cv<'a>, f: Box<dyn Update<'a> + 'a>) -> ValRs {
         use core::iter::once;
-        let err = Box::new(core::iter::once(Err(Error::PathExp)));
+        let err = Box::new(once(Err(Error::PathExp)));
         match self {
             Self::Int(_) | Self::Float(_) | Self::Str(_) => err,
             Self::Array(_) | Self::Object(_) => err,
@@ -446,9 +446,9 @@ impl Filter {
                 let (save, rec) = &cv.0.recs[*id];
                 rec.update((cv.0.save_skip_vars(*save, *skip), cv.1), f)
             }
-            
+
             Self::Custom(CustomFilter { update: Some(update), .. }) => (update)(cv.clone(), f.clone()),
-            Self::Custom(CustomFilter { update: None, .. }) => err,
+            Self::Custom(CustomFilter { update: None, .. }) => Box::new(once(Err(Error::NonUpdatable))),
         }
     }
 

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -162,8 +162,8 @@ impl Definitions {
     }
     
     /// Import a custom, Rust-defined filter.
-    pub fn insert_custom(&mut self, name: &str, arity: usize, filter: filter::CustomFilter) {
-        self.0.insert((name.to_string(), arity), filter::Filter::Custom(filter));
+    pub fn insert_custom(&mut self, name: &str, filter: filter::CustomFilter) {
+        self.0.insert((name.to_string(), filter.arity()), filter::Filter::Custom(filter));
     }
 
     /// Given a main filter (consisting of definitions and a body), return a finished filter.

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -60,10 +60,11 @@ mod val;
 pub use jaq_parse as parse;
 
 pub use error::Error;
+pub use filter::CustomFilter;
 pub use rc_iter::RcIter;
 pub use val::{Val, ValR};
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::{String, ToString}, vec::Vec};
 use lazy_iter::LazyIter;
 use parse::{Def, Main};
 use rc_list::RcList;
@@ -141,6 +142,7 @@ impl Filter {
 ///
 /// For example, if we define a filter `def map(f): [.[] | f]`,
 /// then the definitions will associate `map/1` to its definition.
+#[derive(Debug, Default, Clone)]
 pub struct Definitions(BTreeMap<(String, usize), filter::Filter>);
 
 impl Definitions {
@@ -157,6 +159,11 @@ impl Definitions {
     pub fn insert(&mut self, def: Def, errs: &mut Vec<parse::Error>) {
         let f = unparse::def(&self.get(), &def.args, def.body, errs);
         self.0.insert((def.name, def.args.len()), f);
+    }
+    
+    /// Import a custom, Rust-defined filter.
+    pub fn insert_custom(&mut self, name: &str, arity: usize, filter: filter::CustomFilter) {
+        self.0.insert((name.to_string(), arity), filter::Filter::Custom(filter));
     }
 
     /// Given a main filter (consisting of definitions and a body), return a finished filter.

--- a/jaq-core/tests/custom.rs
+++ b/jaq-core/tests/custom.rs
@@ -111,7 +111,11 @@ fn arity1() {
             let arg = match args[0].run((ctx.clone(), val.clone())).next() {
                 Some(Ok(v)) => v,
                 Some(Err(e)) => return Box::new(once(Err(e))),
-                None => return Box::new(once(Err(Error::NoValue))),
+                None => {
+                    return Box::new(once(Err(Error::Custom(
+                        "value expected but none found".into(),
+                    ))))
+                }
             };
 
             Box::new(once(
@@ -138,7 +142,11 @@ fn arity2() {
                     Err(e) => return Box::new(once(Err(e))),
                 },
                 Some(Err(e)) => return Box::new(once(Err(e))),
-                None => return Box::new(once(Err(Error::NoValue))),
+                None => {
+                    return Box::new(once(Err(Error::Custom(
+                        "value expected but none found".into(),
+                    ))))
+                }
             };
             let max = match args[1].run((ctx.clone(), val.clone())).next() {
                 Some(Ok(v)) => match v.as_int() {
@@ -146,18 +154,37 @@ fn arity2() {
                     Err(e) => return Box::new(once(Err(e))),
                 },
                 Some(Err(e)) => return Box::new(once(Err(e))),
-                None => return Box::new(once(Err(Error::NoValue))),
+                None => {
+                    return Box::new(once(Err(Error::Custom(
+                        "value expected but none found".into(),
+                    ))))
+                }
             };
 
-            Box::new(once(
-                val.to_str()
-                    .map(|s| if s.len() >= min && s.len() <= max { Val::Str(s) } else { Val::Null }),
-            ))
+            Box::new(once(val.to_str().map(|s| {
+                if s.len() >= min && s.len() <= max {
+                    Val::Str(s)
+                } else {
+                    Val::Null
+                }
+            })))
         }),
     );
 
-    yields(&defs, json!("hello"), "ifwithin(7; 11)", [Value::Null], None);
-    yields(&defs, json!("hello"), "ifwithin(3; 8)", [json!("hello")], None);
+    yields(
+        &defs,
+        json!("hello"),
+        "ifwithin(7; 11)",
+        [Value::Null],
+        None,
+    );
+    yields(
+        &defs,
+        json!("hello"),
+        "ifwithin(3; 8)",
+        [json!("hello")],
+        None,
+    );
 }
 
 #[test]
@@ -174,7 +201,11 @@ fn arity12() {
                         Err(e) => return Box::new(once(Err(e))),
                     },
                     Some(Err(e)) => return Box::new(once(Err(e))),
-                    None => return Box::new(once(Err(Error::NoValue))),
+                    None => {
+                        return Box::new(once(Err(Error::Custom(
+                            "value expected but none found".into(),
+                        ))))
+                    }
                 };
             }
 
@@ -182,5 +213,11 @@ fn arity12() {
         }),
     );
 
-    yields(&defs, Value::Null, "sillysum(6; 13; 15; 8; 10; 12; 20; 16; 20; 3; 17; 8)", [json!(148)], None);
+    yields(
+        &defs,
+        Value::Null,
+        "sillysum(6; 13; 15; 8; 10; 12; 20; 16; 20; 3; 17; 8)",
+        [json!(148)],
+        None,
+    );
 }

--- a/jaq-core/tests/custom.rs
+++ b/jaq-core/tests/custom.rs
@@ -156,8 +156,8 @@ fn arity2() {
         }),
     );
 
-    yields(&defs, json!("hello"), "ifwithin(7, 11)", [Value::Null], None);
-    yields(&defs, json!("hello"), "ifwithin(3, 8)", [json!("hello")], None);
+    yields(&defs, json!("hello"), "ifwithin(7; 11)", [Value::Null], None);
+    yields(&defs, json!("hello"), "ifwithin(3; 8)", [json!("hello")], None);
 }
 
 #[test]
@@ -182,5 +182,5 @@ fn arity12() {
         }),
     );
 
-    yields(&defs, Value::Null, "sillysum(6, 13, 15, 8, 10, 12, 20, 16, 20, 3, 17, 8)", [json!(101)], None);
+    yields(&defs, Value::Null, "sillysum(6; 13; 15; 8; 10; 12; 20; 16; 20; 3; 17; 8)", [json!(148)], None);
 }

--- a/jaq-core/tests/custom.rs
+++ b/jaq-core/tests/custom.rs
@@ -1,0 +1,47 @@
+//! Tests for custom filters.
+
+use std::{iter, rc::Rc};
+
+use jaq_core::{parse, Ctx, Definitions, Error, RcIter, Val, CustomFilter};
+use serde_json::{json, Value};
+
+pub fn yields<const N: usize>(defs: &Definitions, x: Value, f: &str, ys: [Value; N], err: Option<Error>) {
+    let f = parse::parse(&f, parse::main()).0.unwrap();
+    
+    let mut errs = Vec::new();
+    let f = defs.clone().finish(f, Vec::new(), &mut errs);
+    assert_eq!(errs, Vec::new());
+
+    let to = |v| Val::from(v);
+
+    let expected = ys.into_iter().map(|y| Ok(to(y)));
+    let expected: Vec<_> = expected.chain(err.into_iter().map(Err)).collect();
+
+    let inputs = RcIter::new(core::iter::empty());
+    let out: Vec<_> = f.run(Ctx::new([], &inputs), to(x)).collect();
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn arity0() {
+    let mut defs = Definitions::core();
+    defs.insert_custom("natzero", 0, CustomFilter::new(
+        |_cv| {
+            Box::new(iter::once(Ok(Val::Int(0))))
+        },
+    ));
+    defs.insert_custom("nattwenty", 0, CustomFilter::new(
+        |_cv| {
+            Box::new(iter::once(Ok(Val::Int(20))))
+        },
+    ));
+    defs.insert_custom("hello", 0, CustomFilter::new(
+        |_cv| {
+            Box::new(iter::once(Ok(Val::Str(Rc::new("world".into())))))
+        },
+    ));
+
+    yields(&defs, Value::Null, "natzero", [json!(0)], None);
+    yields(&defs, Value::Null, "nattwenty", [json!(20)], None);
+    yields(&defs, Value::Null, "hello", [json!("world")], None);
+}

--- a/jaq-core/tests/custom.rs
+++ b/jaq-core/tests/custom.rs
@@ -107,10 +107,11 @@ fn arity1() {
     let mut defs = Definitions::core();
     defs.insert_custom(
         "iflonger",
-        CustomFilter::new(1, |mut args, (ctx, val)| {
-            let arg = match args.next().unwrap().next() {
-                Some(Ok(val)) => val,
-                Some(err @ Err(_)) => return Box::new(once(err)),
+        CustomFilter::new(1, |args, (ctx, val)| {
+            dbg!(args);
+            let arg = match args[0].run((ctx.clone(), val.clone())).next() {
+                Some(Ok(v)) => v,
+                Some(Err(e)) => return Box::new(once(Err(e))),
                 None => return Box::new(once(Err(Error::NoValue))),
             };
 
@@ -122,6 +123,6 @@ fn arity1() {
         }),
     );
 
-    yields(&defs, json!("hello"), "iflonger(8)", [Value::Null], None);
-    yields(&defs, json!("helloworld"), "iflonger(8)", [json!("helloworld")], None);
+    yields(&defs, json!("hello"), "iflonger(6)", [Value::Null], None);
+    yields(&defs, json!("hello"), "iflonger(3)", [json!("hello")], None);
 }

--- a/jaq-core/tests/custom.rs
+++ b/jaq-core/tests/custom.rs
@@ -1,13 +1,20 @@
 //! Tests for custom filters.
 
-use std::{iter, rc::Rc};
+use std::{iter::once, rc::Rc};
 
-use jaq_core::{parse, Ctx, Definitions, Error, RcIter, Val, CustomFilter};
+use itertools::Itertools;
+use jaq_core::{parse, Ctx, CustomFilter, Definitions, Error, RcIter, Val};
 use serde_json::{json, Value};
 
-pub fn yields<const N: usize>(defs: &Definitions, x: Value, f: &str, ys: [Value; N], err: Option<Error>) {
+pub fn yields<const N: usize>(
+    defs: &Definitions,
+    x: Value,
+    f: &str,
+    ys: [Value; N],
+    err: Option<Error>,
+) {
     let f = parse::parse(&f, parse::main()).0.unwrap();
-    
+
     let mut errs = Vec::new();
     let f = defs.clone().finish(f, Vec::new(), &mut errs);
     assert_eq!(errs, Vec::new());
@@ -23,25 +30,42 @@ pub fn yields<const N: usize>(defs: &Definitions, x: Value, f: &str, ys: [Value;
 }
 
 #[test]
-fn arity0() {
+fn arity0_source_only() {
     let mut defs = Definitions::core();
-    defs.insert_custom("natzero", 0, CustomFilter::new(
-        |_cv| {
-            Box::new(iter::once(Ok(Val::Int(0))))
-        },
-    ));
-    defs.insert_custom("nattwenty", 0, CustomFilter::new(
-        |_cv| {
-            Box::new(iter::once(Ok(Val::Int(20))))
-        },
-    ));
-    defs.insert_custom("hello", 0, CustomFilter::new(
-        |_cv| {
-            Box::new(iter::once(Ok(Val::Str(Rc::new("world".into())))))
-        },
-    ));
+    defs.insert_custom(
+        "natzero",
+        0,
+        CustomFilter::new(|_cv| Box::new(once(Ok(Val::Int(0))))),
+    );
+    defs.insert_custom(
+        "nattwenty",
+        0,
+        CustomFilter::new(|_cv| Box::new(once(Ok(Val::Int(20))))),
+    );
+    defs.insert_custom(
+        "hello",
+        0,
+        CustomFilter::new(|_cv| Box::new(once(Ok(Val::Str(Rc::new("world".into())))))),
+    );
 
     yields(&defs, Value::Null, "natzero", [json!(0)], None);
     yields(&defs, Value::Null, "nattwenty", [json!(20)], None);
     yields(&defs, Value::Null, "hello", [json!("world")], None);
+}
+
+#[test]
+fn arity0_and_sink() {
+    let mut defs = Definitions::core();
+    defs.insert_custom(
+        "str_rev",
+        0,
+        CustomFilter::new(|(_, val)| {
+            Box::new(once(
+                val.to_str().map(|s| Val::str(s.chars().rev().join(""))),
+            ))
+        }),
+    );
+
+    yields(&defs, json!("hello"), "str_rev", [json!("olleh")], None);
+    yields(&defs, json!(""), "str_rev", [json!("")], None);
 }


### PR DESCRIPTION
Introduces the `CustomFilter` type and a new method `Definitions.insert_custom(name, filter)`. Custom filters can be constructed from an arity, a run function, and an optional update function. If no update function is provided, the filter cannot be used like `filter |= ...`.

No particular care is taken to make writing filters ergonomic, but it's fairly straightforward nonetheless. For example, here's a basic sqrt:

```rust
defs.insert_custom("sqrt", CustomFilter::new(0, |_, (_, val)| {
    Box::new(std::iter::once(match val {
        Val::Float(f) => Ok(Val::Float(f.sqrt())),
        _ => Err(jaq_core::Error::Custom(format!("sqrt: expected float, got {val:?}"))),
    }))
}));
```

Also:
- Adds Clone derive (and Debug, Default) to `Definitions` so it's easier to use in tests to call multiple times.
- Adds two new errors: `NonUpdatable` for custom filters that can't be used in update position, and `Custom`, for use _by_ custom filters.

Fixes #69