### PR TITLE
Fix Native filters

### DIFF
--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -137,6 +137,7 @@ impl Filter {
 ///
 /// For example, if we define a filter `def map(f): [.[] | f]`,
 /// then the definitions will associate `map/1` to its definition.
+#[derive(Debug, Clone)]
 pub struct Definitions(mir::Defs);
 
 impl Definitions {

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -61,6 +61,7 @@ mod val;
 pub use jaq_parse as parse;
 
 pub use error::Error;
+pub use filter::Native;
 pub use rc_iter::RcIter;
 pub use val::{Val, ValR};
 

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -141,6 +141,12 @@ impl Filter {
 #[derive(Debug, Clone)]
 pub struct Definitions(mir::Defs);
 
+impl Default for Definitions {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
 impl Definitions {
     /// Create new definitions that have access to global variables of the given names.
     pub fn new(vars: Vec<String>) -> Self {

--- a/jaq-core/src/mir.rs
+++ b/jaq-core/src/mir.rs
@@ -2,7 +2,6 @@
 //!
 //! This is quite close to the output of parsing,
 //! but replaces names by unique integers.
-//! This makes the subsequent transformation step ,
 //! That way, the subsequent transformation step(s)
 //! always succeed and do not have to fight with shadowing.
 //! But most importantly, this allows us to record recursive calls.
@@ -42,12 +41,12 @@ impl Num {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Defs(Vec<Def>, Vec<(String, usize, crate::filter::Native)>);
 
 pub type Filter = parse::filter::Filter<Call, VarIdx, Num>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Def {
     pub name: String,
     pub args: Vec<Arg>,

--- a/jaq-core/tests/custom.rs
+++ b/jaq-core/tests/custom.rs
@@ -1,6 +1,5 @@
-//! Tests for custom filters.
+//! Tests for custom native filters.
 
-/*
 use std::{iter::once, rc::Rc};
 
 use jaq_core::{parse, Ctx, CustomFilter, Definitions, Error, RcIter, Val};
@@ -256,4 +255,3 @@ fn iterator() {
         None,
     );
 }
-*/

--- a/jaq-parse/src/toplevel.rs
+++ b/jaq-parse/src/toplevel.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// A definition, such as `def map(f): [.[] | f];`.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Def {
     /// Name of the filter, e.g. `map`
     pub name: String,
@@ -21,7 +21,7 @@ pub struct Def {
 
 /// Argument of a definition, such as `$v` or `f` in `def foo($v; f): ...`.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Arg {
     name: String,
     var: bool,


### PR DESCRIPTION
- Publicly expose `filter::Native` -- otherwise that API just can't be used!
- Re-enable (and fix the types of) the custom filters integration tests -- probably why you didn't catch that this broke during your refactors.
- Derive `Clone` on Definitions again, and add `Default`, to cover the case where there's no variables -- can just be done with `Definitions::new(Vec::new())` though so this is a small convenience only.