### PR TITLE
docs: Mention unique under core filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Here is an overview that summarises:
 - [x] Stream generators (`range`, `recurse`)
 - [ ] More numeric filters (`sqrt`, `sin`, `log`, `pow`, ...)
 - [ ] More string filters (`startswith`, `ltrimstr`, ...)
-- [ ] More array filters (`group_by`, `min_by`, `max_by`, ...)
+- [ ] More array filters (`group_by`, `min_by`, `max_by`, `unique`, ...)
 
 
 ## Standard filters


### PR DESCRIPTION
```
$ echo '[1,2,5,3,5,3,1,3]' | jaq 'unique'
Error: could not find function
```

Adding to docs to make it easier to confirm that it's not implemented.