### PR TITLE
Add keys_unsorted

### DIFF
--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -83,7 +83,9 @@ const CORE: [(&str, usize, RunPtr); 28] = [
         Box::new(cv.0.inputs.map(|r| r.map_err(Error::Parse)))
     }),
     ("length", 0, |_, cv| box_once(cv.1.len())),
-    ("keys", 0, |_, cv| box_once(cv.1.keys().map(Val::arr))),
+    ("keys_unsorted", 0, |_, cv| {
+        box_once(cv.1.keys().map(Val::arr))
+    }),
     ("floor", 0, |_, cv| box_once(cv.1.round(|f| f.floor()))),
     ("round", 0, |_, cv| box_once(cv.1.round(|f| f.round()))),
     ("ceil", 0, |_, cv| box_once(cv.1.round(|f| f.ceil()))),

--- a/jaq-core/tests/named.rs
+++ b/jaq-core/tests/named.rs
@@ -72,12 +72,12 @@ fn json() {
 }
 
 #[test]
-fn keys() {
-    give(json!([0, null, "a"]), "keys", json!([0, 1, 2]));
-    give(json!({"a": 1, "b": 2}), "keys", json!(["a", "b"]));
+fn keys_unsorted() {
+    give(json!([0, null, "a"]), "keys_unsorted", json!([0, 1, 2]));
+    give(json!({"a": 1, "b": 2}), "keys_unsorted", json!(["a", "b"]));
 
-    fail(json!(0), "keys", Error::Keys(Val::Int(0)));
-    fail(json!(null), "keys", Error::Keys(Val::Null));
+    fail(json!(0), "keys_unsorted", Error::Keys(Val::Int(0)));
+    fail(json!(null), "keys_unsorted", Error::Keys(Val::Null));
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn recurse() {
 
 const RECURSE_PATHS: &str = "def paths:
   { x: ., p: [] } |
-  recurse((.x | keys?)[] as $k | .x |= .[$k] | .p += [$k]) |
+  recurse((.x | keys_unsorted?)[] as $k | .x |= .[$k] | .p += [$k]) |
   .p | if . == [] then empty else . end;";
 
 yields!(

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -62,7 +62,7 @@ fn alt() {
 #[test]
 fn try_() {
     give(json!(0), ".?", json!(0));
-    give(json!(0), "keys?, 1", json!(1));
+    give(json!(0), "keys_unsorted?, 1", json!(1));
     give(json!(0), "[(1, error, 2)?]", json!([1, 2]));
 }
 

--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -78,6 +78,7 @@ def nth(n): .[ n];
 def nth(n; g): last(limit(n + 1; g));
 
 # Objects <-> Arrays
+def keys: keys_unsorted | sort;
 def   to_entries: [keys[] as $k | { key: $k, value: .[$k] }];
 def from_entries: map({ (.key): .value }) | add + {};
 def with_entries(f): to_entries | map(f) | from_entries;

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -108,6 +108,12 @@ yields!(join_nums, r#"[2, 3, 4, 5] | join(1)"#, 17);
 
 yields!(map, "[1, 2] | map(.+1)", [2, 3]);
 
+yields!(
+    keys,
+    r#"{"foo":null,"abc":null,"fax":null,"az":null} | keys"#,
+    ["abc", "az", "fax", "foo"]
+);
+
 #[test]
 fn min_max() {
     give(json!([]), "min", json!(null));


### PR DESCRIPTION
To match jq, rename `keys` to `keys_unsorted` and implement `keys` as a std filter based on `keys_unsorted`. `keys` now returns the array of keys sorted
