### PR TITLE
Implement utf8bytelength function

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Here is an overview that summarises:
 - [x] Empty (`empty`)
 - [x] Errors (`error`)
 - [x] Input (`inputs`)
-- [x] Length (`length`)
+- [x] Length (`length`, `utf8bytelength`)
 - [x] Rounding (`floor`, `round`, `ceil`)
 - [x] String <-> JSON (`fromjson`, `tojson`)
 - [x] String <-> integers (`explode`, `implode`)

--- a/jaq-core/src/error.rs
+++ b/jaq-core/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     Arr(Val),
     /// `0 == 0 | length`
     Length(Val),
+    /// `0 == 0 | utf8bytelength`
+    ByteLength(Val),
     /// `"a" | round`
     Round(Val),
     /// `"[1, 2" | fromjson`
@@ -64,6 +66,7 @@ impl fmt::Display for Error {
             Self::Str(v) => write!(f, "cannot use {v} as string"),
             Self::Arr(v) => write!(f, "cannot use {v} as array"),
             Self::Length(v) => write!(f, "{v} has no length"),
+            Self::ByteLength(v) => write!(f, "only strings have UTF-8 byte length: {v}"),
             Self::Round(v) => write!(f, "cannot round {v}"),
             Self::FromJson(v, why) => write!(f, "cannot parse {v} as JSON: {why}"),
             Self::Keys(v) => write!(f, "{v} has no keys"),

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -78,11 +78,12 @@ fn box_once<'a, T: 'a>(x: T) -> Box<dyn Iterator<Item = T> + 'a> {
     Box::new(core::iter::once(x))
 }
 
-const CORE: [(&str, usize, RunPtr); 28] = [
+const CORE: [(&str, usize, RunPtr); 29] = [
     ("inputs", 0, |_, cv| {
         Box::new(cv.0.inputs.map(|r| r.map_err(Error::Parse)))
     }),
     ("length", 0, |_, cv| box_once(cv.1.len())),
+    ("utf8bytelength", 0, |_, cv| box_once(cv.1.byte_len())),
     ("keys", 0, |_, cv| box_once(cv.1.keys().map(Val::arr))),
     ("floor", 0, |_, cv| box_once(cv.1.round(|f| f.floor()))),
     ("round", 0, |_, cv| box_once(cv.1.round(|f| f.round()))),

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -83,7 +83,6 @@ const CORE: [(&str, usize, RunPtr); 29] = [
         Box::new(cv.0.inputs.map(|r| r.map_err(Error::Parse)))
     }),
     ("length", 0, |_, cv| box_once(cv.1.len())),
-    ("keys", 0, |_, cv| box_once(cv.1.keys().map(Val::arr))),
     ("keys_unsorted", 0, |_, cv| {
         box_once(cv.1.keys().map(Val::arr))
     }),

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -148,6 +148,16 @@ impl Val {
         }
     }
 
+    /// Return the number of bytes used to encode a string in UTF-8
+    ///
+    /// Fail on any other value.
+    pub fn byte_len(&self) -> Result<Self, Error> {
+        match self {
+            Self::Str(s) => Ok(Self::Int(s.len() as isize)),
+            _ => Err(Error::ByteLength(self.clone())),
+        }
+    }
+
     /// Apply a rounding function to floating-point numbers, then convert them to integers.
     ///
     /// Return integers unchanged, and fail on any other input.

--- a/jaq-core/tests/named.rs
+++ b/jaq-core/tests/named.rs
@@ -92,6 +92,13 @@ fn length() {
 }
 
 #[test]
+fn utf8bytelength() {
+    give(json!("foo"), "utf8bytelength", json!(3));
+    give(json!("ƒoo"), "utf8bytelength", json!(4));
+    give(json!("नमस्ते"), "utf8bytelength", json!(18));
+}
+
+#[test]
 fn limit() {
     // a big WTF: jq outputs "1" here! that looks like another bug ...
     gives(json!(null), "limit(0; 1,2)", []);


### PR DESCRIPTION
For jq parity, adds byte-length function for strings.