### PR TITLE
Imeplement string functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Here is an overview that summarises:
 - [x] Stream consumers (`first`, `last`, `range`, `fold`)
 - [x] Stream generators (`range`, `recurse`)
 - [ ] More numeric filters (`sqrt`, `sin`, `log`, `pow`, ...)
-- [ ] More string filters (`startswith`, `ltrimstr`, ...)
+- [x] More string filters (`startswith`, `endswith`, `ltrimstr`, `rtrimstr`)
 - [ ] More array filters (`group_by`, `min_by`, `max_by`, ...)
 
 

--- a/jaq-core/src/error.rs
+++ b/jaq-core/src/error.rs
@@ -52,6 +52,8 @@ pub enum Error {
     RegexFlag(char),
     /// `123 | startswith("x")`
     StartsWith(Val, Val),
+    /// `123 | endswith("x")`
+    EndsWith(Val, Val),
     /// arbitrary errors for custom filters
     Custom(String),
 }
@@ -82,6 +84,7 @@ impl fmt::Display for Error {
             Self::Regex(e) => write!(f, "invalid regex: {e}"),
             Self::RegexFlag(c) => write!(f, "invalid regex flag '{c}'"),
             Self::StartsWith(l, r) => write!(f, "cannot check whether {l} starts with {r}"),
+            Self::EndsWith(l, r) => write!(f, "cannot check whether {l} ends with {r}"),
             Self::Custom(e) => write!(f, "custom filter error: {e}"),
         }
     }

--- a/jaq-core/src/error.rs
+++ b/jaq-core/src/error.rs
@@ -54,6 +54,10 @@ pub enum Error {
     StartsWith(Val, Val),
     /// `123 | endswith("x")`
     EndsWith(Val, Val),
+    /// `123 | ltrimstr("x")`
+    StripPrefix(Val, Val),
+    /// `123 | rtrimstr("x")`
+    StripSuffix(Val, Val),
     /// arbitrary errors for custom filters
     Custom(String),
 }
@@ -85,6 +89,8 @@ impl fmt::Display for Error {
             Self::RegexFlag(c) => write!(f, "invalid regex flag '{c}'"),
             Self::StartsWith(l, r) => write!(f, "cannot check whether {l} starts with {r}"),
             Self::EndsWith(l, r) => write!(f, "cannot check whether {l} ends with {r}"),
+            Self::StripPrefix(l, r) => write!(f, "cannot strip prefix {r} from {l}"),
+            Self::StripSuffix(l, r) => write!(f, "cannot strip suffix {r} from {l}"),
             Self::Custom(e) => write!(f, "custom filter error: {e}"),
         }
     }

--- a/jaq-core/src/error.rs
+++ b/jaq-core/src/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
     Regex(String),
     /// `"a" | test("."; "b")`
     RegexFlag(char),
+    /// `123 | startswith("x")`
+    StartsWith(Val, Val),
     /// arbitrary errors for custom filters
     Custom(String),
 }
@@ -79,6 +81,7 @@ impl fmt::Display for Error {
             Self::PathExp => write!(f, "invalid path expression"),
             Self::Regex(e) => write!(f, "invalid regex: {e}"),
             Self::RegexFlag(c) => write!(f, "invalid regex flag '{c}'"),
+            Self::StartsWith(l, r) => write!(f, "cannot check whether {l} starts with {r}"),
             Self::Custom(e) => write!(f, "custom filter error: {e}"),
         }
     }

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -78,7 +78,7 @@ fn box_once<'a, T: 'a>(x: T) -> Box<dyn Iterator<Item = T> + 'a> {
     Box::new(core::iter::once(x))
 }
 
-const CORE: [(&str, usize, RunPtr); 28] = [
+const CORE: [(&str, usize, RunPtr); 29] = [
     ("inputs", 0, |_, cv| {
         Box::new(cv.0.inputs.map(|r| r.map_err(Error::Parse)))
     }),
@@ -160,6 +160,10 @@ const CORE: [(&str, usize, RunPtr); 28] = [
     }),
     ("recurse_outer", 1, |args, cv| {
         args[0].recurse1(false, true, cv)
+    }),
+    ("startswith", 1, |args, cv| {
+        let keys = args[0].run(cv.clone());
+        Box::new(keys.map(move |k| Ok(Val::Bool(cv.1.starts_with(&k?)?))))
     }),
 ];
 

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -78,7 +78,7 @@ fn box_once<'a, T: 'a>(x: T) -> Box<dyn Iterator<Item = T> + 'a> {
     Box::new(core::iter::once(x))
 }
 
-const CORE: [(&str, usize, RunPtr); 29] = [
+const CORE: [(&str, usize, RunPtr); 30] = [
     ("inputs", 0, |_, cv| {
         Box::new(cv.0.inputs.map(|r| r.map_err(Error::Parse)))
     }),
@@ -164,6 +164,10 @@ const CORE: [(&str, usize, RunPtr); 29] = [
     ("startswith", 1, |args, cv| {
         let keys = args[0].run(cv.clone());
         Box::new(keys.map(move |k| Ok(Val::Bool(cv.1.starts_with(&k?)?))))
+    }),
+    ("endswith", 1, |args, cv| {
+        let keys = args[0].run(cv.clone());
+        Box::new(keys.map(move |k| Ok(Val::Bool(cv.1.ends_with(&k?)?))))
     }),
 ];
 

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -78,7 +78,7 @@ fn box_once<'a, T: 'a>(x: T) -> Box<dyn Iterator<Item = T> + 'a> {
     Box::new(core::iter::once(x))
 }
 
-const CORE: [(&str, usize, RunPtr); 30] = [
+const CORE: [(&str, usize, RunPtr); 32] = [
     ("inputs", 0, |_, cv| {
         Box::new(cv.0.inputs.map(|r| r.map_err(Error::Parse)))
     }),
@@ -168,6 +168,14 @@ const CORE: [(&str, usize, RunPtr); 30] = [
     ("endswith", 1, |args, cv| {
         let keys = args[0].run(cv.clone());
         Box::new(keys.map(move |k| Ok(Val::Bool(cv.1.ends_with(&k?)?))))
+    }),
+    ("ltrimstr", 1, |args, cv| {
+        let keys = args[0].run(cv.clone());
+        Box::new(keys.map(move |k| Ok(Val::Str(cv.1.strip_prefix(&k?)?.into()))))
+    }),
+    ("rtrimstr", 1, |args, cv| {
+        let keys = args[0].run(cv.clone());
+        Box::new(keys.map(move |k| Ok(Val::Str(cv.1.strip_suffix(&k?)?.into()))))
     }),
 ];
 

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -312,6 +312,32 @@ impl Val {
         }
     }
 
+    /// Return a string with the given prefix string removed
+    ///
+    /// Fail on any other value.
+    pub fn strip_prefix(&self, other: &Self) -> Result<String, Error> {
+        match (self, other) {
+            (Self::Str(s), Self::Str(o)) => match s.strip_prefix(&**o) {
+                Some(res) => Ok(res.into()),
+                None => Ok(s.to_string()),
+            },
+            _ => Err(Error::StripPrefix(self.clone(), other.clone())),
+        }
+    }
+
+    /// Return a string with the given suffix string removed
+    ///
+    /// Fail on any other value.
+    pub fn strip_suffix(&self, other: &Self) -> Result<String, Error> {
+        match (self, other) {
+            (Self::Str(s), Self::Str(o)) => match s.strip_suffix(&**o) {
+                Some(res) => Ok(res.into()),
+                None => Ok(s.to_string()),
+            },
+            _ => Err(Error::StripSuffix(self.clone(), other.clone())),
+        }
+    }
+
     /// Group an array by the given function.
     ///
     /// Fail on any other value.

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -292,6 +292,16 @@ impl Val {
         err.map_or(Ok(Val::Arr(a)), Err)
     }
 
+    /// Return true if string starts with a given string.
+    ///
+    /// Fail on any other value.
+    pub fn starts_with(&self, other: &Self) -> Result<bool, Error> {
+        match (self, other) {
+            (Self::Str(s), Self::Str(o)) => Ok(s.starts_with(&**o)),
+            _ => Err(Error::StartsWith(self.clone(), other.clone())),
+        }
+    }
+
     /// Group an array by the given function.
     ///
     /// Fail on any other value.

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -302,6 +302,16 @@ impl Val {
         }
     }
 
+    /// Return true if string ends with a given string.
+    ///
+    /// Fail on any other value.
+    pub fn ends_with(&self, other: &Self) -> Result<bool, Error> {
+        match (self, other) {
+            (Self::Str(s), Self::Str(o)) => Ok(s.ends_with(&**o)),
+            _ => Err(Error::EndsWith(self.clone(), other.clone())),
+        }
+    }
+
     /// Group an array by the given function.
     ///
     /// Fail on any other value.

--- a/jaq-core/tests/named.rs
+++ b/jaq-core/tests/named.rs
@@ -201,3 +201,11 @@ fn startswith() {
     give(json!("foobar"), r#"startswith("foo")"#, json!(true));
     give(json!(""), r#"startswith("foo")"#, json!(false));
 }
+
+#[test]
+fn endswith() {
+    give(json!("foobar"), r#"endswith("")"#, json!(true));
+    give(json!("foobar"), r#"endswith("foo")"#, json!(false));
+    give(json!("foobar"), r#"endswith("bar")"#, json!(true));
+    give(json!(""), r#"endswith("foo")"#, json!(false));
+}

--- a/jaq-core/tests/named.rs
+++ b/jaq-core/tests/named.rs
@@ -193,3 +193,11 @@ fn split() {
         json!(["", "c", "cd", ""]),
     );
 }
+
+#[test]
+fn startswith() {
+    give(json!("foobar"), r#"startswith("")"#, json!(true));
+    give(json!("foobar"), r#"startswith("bar")"#, json!(false));
+    give(json!("foobar"), r#"startswith("foo")"#, json!(true));
+    give(json!(""), r#"startswith("foo")"#, json!(false));
+}

--- a/jaq-core/tests/named.rs
+++ b/jaq-core/tests/named.rs
@@ -209,3 +209,19 @@ fn endswith() {
     give(json!("foobar"), r#"endswith("bar")"#, json!(true));
     give(json!(""), r#"endswith("foo")"#, json!(false));
 }
+
+#[test]
+fn ltrimstr() {
+    give(json!("foobar"), r#"ltrimstr("")"#, json!("foobar"));
+    give(json!("foobar"), r#"ltrimstr("foo")"#, json!("bar"));
+    give(json!("foobar"), r#"ltrimstr("bar")"#, json!("foobar"));
+    give(json!("اَلْعَرَبِيَّةُ"), r#"ltrimstr("ا")"#, json!("َلْعَرَبِيَّةُ"));
+}
+
+#[test]
+fn rtrimstr() {
+    give(json!("foobar"), r#"rtrimstr("")"#, json!("foobar"));
+    give(json!("foobar"), r#"rtrimstr("bar")"#, json!("foo"));
+    give(json!("foobar"), r#"rtrimstr("foo")"#, json!("foobar"));
+    give(json!("اَلْعَرَبِيَّةُ"), r#"rtrimstr("ا")"#, json!("اَلْعَرَبِيَّةُ"));
+}


### PR DESCRIPTION
Adds all (AFAICT) of the missing string functions:

* `startswith`
* `endswith`
* `ltrimstr`
* `rtrimstr`