### PR TITLE
Implement --nul-output

### DIFF
--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -62,6 +62,8 @@ struct Cli {
     join_output: bool,
 
     /// Print NUL after each value, instead of a newline
+    ///
+    /// Unlike jq, this does not enable `--raw-output`.
     #[arg(short = '0', long)]
     nul_output: bool,
 

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -61,6 +61,10 @@ struct Cli {
     #[arg(short, long)]
     join_output: bool,
 
+    /// Print NUL after each value, instead of a newline
+    #[arg(short = '0', long)]
+    nul_output: bool,
+
     /// Color output
     #[arg(long, value_name = "WHEN", default_value = "auto")]
     color: Color,
@@ -436,7 +440,9 @@ fn print(cli: &Cli, val: Val, writer: &mut impl Write) -> io::Result<()> {
             }?
         }
     };
-    if !cli.join_output {
+    if cli.nul_output {
+        write!(writer, "\0")?
+    } else if !cli.join_output {
         writeln!(writer)?
     }
     Ok(())


### PR DESCRIPTION
For compatibility with jq's upcoming release.

Introduced to jq in https://github.com/jqlang/jq/pull/1990

Note that JSON can contain NUL characters (e.g. `"\u0000"`), so it is not possible to distinguish separate values in every case, even when using this flag