### PR TITLE
Match jq exit code for no output with --exit-status

### DIFF
--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -179,12 +179,14 @@ fn real_main() -> Result<ExitCode, Error> {
         last
     };
 
-    Ok(if cli.exit_status {
-        // return exit code 4 if no value is output
-        ExitCode::from(last.map(|b| (!b).into()).unwrap_or(4))
+    if cli.exit_status {
+        last.map_or_else(
+            || Err(Error::NoOutput),
+            |b| b.then_some(ExitCode::SUCCESS).ok_or(Error::FalseOrNull),
+        )
     } else {
-        ExitCode::SUCCESS
-    })
+        Ok(ExitCode::SUCCESS)
+    }
 }
 
 fn bind<F>(var_val: &mut Vec<(String, Val)>, args: &[String], f: F) -> Result<(), Error>
@@ -335,11 +337,14 @@ enum Error {
     Parse(String),
     Jaq(jaq_core::Error),
     Persist(tempfile::PersistError),
+    FalseOrNull,
+    NoOutput,
 }
 
 impl Termination for Error {
     fn report(self) -> ExitCode {
         let exit = match self {
+            Self::FalseOrNull => 1,
             Self::Io(prefix, e) => {
                 eprint!("Error: ");
                 prefix.into_iter().for_each(|p| eprint!("{}: ", p));
@@ -358,9 +363,10 @@ impl Termination for Error {
                 }
                 3
             }
+            Self::NoOutput => 4,
             Self::Parse(e) => {
                 eprintln!("Error: failed to parse: {}", e);
-                4
+                5
             }
             Self::Jaq(e) => {
                 eprintln!("Error: {}", e);


### PR DESCRIPTION
For compatibility with jq's upcoming (1.7?) release.

Introduced into jq with https://github.com/jqlang/jq/pull/2654, when using --exit-status, parse errors now cause jq to exit with status code 5 (`JQ_ERROR_UNKNOWN`) instead of 4 (`JQ_OK_NO_OUTPUT`). The motivation is to be able to distinguish the no-output case from parsing errors.

Mirroring this, 5 will be used for both `Error::Jaq` and `Error::Parse`, i.e. both filter parsing errors and JSON parsing errors.