### PR TITLE
add aliases for date funcs

### DIFF
--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -128,3 +128,7 @@ def gsub(re; f): sub(re; f; "g");
 
 # I/O
 def input: first(inputs);
+
+# Date
+def   todate:   todateiso8601;
+def fromdate: fromdateiso8601;

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -26,6 +26,23 @@ fn any() {
 }
 
 #[test]
+fn date() {
+    // aliases for fromdateiso8601 and todateiso8601
+    give(json!("1970-01-02T00:00:00Z"), "fromdate", json!(86400));
+    give(
+        json!("1970-01-02T00:00:00.123456789Z"),
+        "fromdate",
+        json!(86400.123456789),
+    );
+    give(json!(86400), "todate", json!("1970-01-02T00:00:00Z"));
+    give(
+        json!(86400.123456789),
+        "todate",
+        json!("1970-01-02T00:00:00.123456789Z"),
+    );
+}
+
+#[test]
 fn entries() {
     let obj = json!({"a": 1, "b": 2});
     let entries = json!([{"key": "a", "value": 1}, {"key": "b", "value": 2}]);

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -43,6 +43,19 @@ fn date() {
 }
 
 #[test]
+fn date_roundtrip() {
+    let epoch = 946684800;
+    give(json!(epoch), "todate|fromdate", json!(epoch));
+    let epoch_ns = 946684800.123456;
+    give(json!(epoch_ns), "todate|fromdate", json!(epoch_ns));
+
+    let iso = "2000-01-01T00:00:00Z";
+    give(json!(iso), "fromdate|todate", json!(iso));
+    let iso_ns = "2000-01-01T00:00:00.123456000Z";
+    give(json!(iso_ns), "fromdate|todate", json!(iso_ns));
+}
+
+#[test]
 fn entries() {
     let obj = json!({"a": 1, "b": 2});
     let entries = json!([{"key": "a", "value": 1}, {"key": "b", "value": 2}]);


### PR DESCRIPTION
For compatibility with jq, alias
`todate` -> `todateiso8601`
and
`fromdate` -> `fromdateiso8601`

closes #58