### PR TITLE
Feature/clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,5 +21,7 @@ jobs:
     - name: Check (without default features)
       working-directory: jaq-native
       run: cargo check --no-default-features
+    - name: Lint
+      run: cargo clippy -- -Dwarnings
     - name: Run tests
       run: cargo test --verbose

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -141,7 +141,7 @@ impl ParseCtx {
         assert!(self.errs.is_empty());
 
         let inputs = RcIter::new(core::iter::empty());
-        let out = f.run((Ctx::new([], &inputs), x.into()));
+        let out = f.run((Ctx::new([], &inputs), x));
         itertools::assert_equal(out, ys);
     }
 }

--- a/jaq-native/src/lib.rs
+++ b/jaq-native/src/lib.rs
@@ -128,7 +128,7 @@ fn strip<F>(s: &Rc<String>, other: &str, f: F) -> Rc<String>
 where
     F: for<'a> Fn(&'a str, &str) -> Option<&'a str>,
 {
-    f(&s, other).map_or_else(|| s.clone(), |stripped| Rc::new(stripped.into()))
+    f(s, other).map_or_else(|| s.clone(), |stripped| Rc::new(stripped.into()))
 }
 
 const CORE_RUN: &[(&str, usize, RunPtr)] = &[


### PR DESCRIPTION
This PR adds a clippy step to the CI workflow, and fixes the current clippy warnings.

Relevant: <https://github.com/rust-lang/rust-clippy/issues/1209>