### PR TITLE
ci: upload jaq executable to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-          echo 'RUSTFLAGS=-Zgcc-ld=lld' >>"$GITHUB_ENV"
+          echo 'CFLAGS=-mno-outline-atomics' >>"$GITHUB_ENV"
           echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: release
+on:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup target add ${{ matrix.target }}
+        shell: bash
+      - if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+      - if: matrix.target == 'aarch64-unknown-linux-musl'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+          echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+      - run: cargo build --release --locked --target ${{ matrix.target }}
+        shell: bash
+      - name: Create artifact for Linux and macOS
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          export ARTIFACT_NAME="jaq-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
+          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
+          cd target/${{ matrix.target }}/release
+          tar czf "../../../${ARTIFACT_NAME}" jaq ../../../LICENSE-MIT -C ../../../ README.md
+
+      - name: Create artifact for Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          export ARTIFACT_NAME="jaq-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
+          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
+          cd target/${{ matrix.target }}/release
+          7z a "../../../${ARTIFACT_NAME}" jaq.exe ../../../LICENSE-MIT ../../../README.md
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: jaq-${{ matrix.target }}
+          path: ${{ env.ARTIFACT_NAME }}
+
+      - name: Release artifact
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v1
+        with:
+          append_body: true
+          files: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross
+      - name: Set up for Windows static build
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >>"$GITHUB_ENV"
       - name: Build
         if: runner.os != 'Linux'
         run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-          echo 'CFLAGS=-mno-outline-atomics"' >>"$GITHUB_ENV"
+          echo 'CFLAGS=-mno-outline-atomics' >>"$GITHUB_ENV"
           echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+          echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          export ARTIFACT_NAME="jaq-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
+          export ARTIFACT_NAME="jaq-${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.tar.gz"
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
           cd target/${{ matrix.target }}/release
           tar czf "../../../${ARTIFACT_NAME}" jaq ../../../LICENSE-MIT -C ../../../ README.md
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         if: runner.os == 'Windows'
         run: |
-          export ARTIFACT_NAME="jaq-v${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
+          export ARTIFACT_NAME="jaq-${{ github.ref_type == 'tag' && github.ref_name || 0 }}-${{ matrix.target }}.zip"
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >>"$GITHUB_ENV"
           cd target/${{ matrix.target }}/release
           7z a "../../../${ARTIFACT_NAME}" jaq.exe ../../../LICENSE-MIT ../../../README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-          echo 'RUSTFLAGS=-Clinker=rust-lld' >>"$GITHUB_ENV"
+          echo 'RUSTFLAGS=-Zgcc-ld=lld' >>"$GITHUB_ENV"
           echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 on:
   release:
     types:
-      - released
+      - published
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,25 +35,20 @@ jobs:
       - name: Set up Rust
         run: rustup target add ${{ matrix.target }}
         shell: bash
-      - name: Install musl-tools
+      - name: Install cross
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
-      - name: Set up for aarch64-unknown-linux-musl
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        shell: bash
-        # Needs to set some environment variables
-        # https://github.com/rust-lang/rust/issues/89626
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-          echo 'CFLAGS=-mno-outline-atomics' >>"$GITHUB_ENV"
-          echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+          curl -sSfLo /tmp/cross.tar.gz https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf /tmp/cross.tar.gz -C /tmp
+          sudo mv /tmp/cross /usr/local/bin/cross
       - name: Build
+        if: runner.os != 'Linux'
         run: cargo build --release --locked --target ${{ matrix.target }}
+        shell: bash
+      - name: Build with cross
+        if: runner.os == 'Linux'
+        run: cross build --release --locked --target ${{ matrix.target }}
         shell: bash
       - name: Create artifact for Linux and macOS
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,9 @@ jobs:
         shell: bash
       - name: Install cross
         if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          curl -sSfLo /tmp/cross.tar.gz https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz
-          tar -xzf /tmp/cross.tar.gz -C /tmp
-          sudo mv /tmp/cross /usr/local/bin/cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
       - name: Build
         if: runner.os != 'Linux'
         run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,20 +32,24 @@ jobs:
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v3
-      - run: rustup target add ${{ matrix.target }}
+      - name: Set up Rust
+        run: rustup target add ${{ matrix.target }}
         shell: bash
-      - if: runner.os == 'Linux'
+      - name: Install musl-tools
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-      - if: matrix.target == 'aarch64-unknown-linux-musl'
+      - name: Set up for aarch64-unknown-linux-musl
+        if: matrix.target == 'aarch64-unknown-linux-musl'
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-      - run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
         shell: bash
       - name: Create artifact for Linux and macOS
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
       - released
   workflow_dispatch:
 
+permissions:
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,13 @@ jobs:
       - name: Set up for aarch64-unknown-linux-musl
         if: matrix.target == 'aarch64-unknown-linux-musl'
         shell: bash
+        # Needs to set some environment variables
+        # https://github.com/rust-lang/rust/issues/89626
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-          echo 'CFLAGS=-mno-outline-atomics' >>"$GITHUB_ENV"
+          echo 'RUSTFLAGS=-Clinker=rust-lld' >>"$GITHUB_ENV"
           echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
+          echo 'CFLAGS=-mno-outline-atomics"' >>"$GITHUB_ENV"
           echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
-          echo 'CC=aarch64-linux-gnu-gcc' >>"$GITHUB_ENV"
       - run: cargo build --release --locked --target ${{ matrix.target }}
         shell: bash
       - name: Create artifact for Linux and macOS


### PR DESCRIPTION
Add a new workflow to upload jaq executable files to GitHub releases.

I have tested on my fork.

![image](https://github.com/01mf02/jaq/assets/50911393/09801129-0a6b-4959-ab62-78d27e705dbc)
