### PR TITLE
Make `else` branch optional

### DIFF
--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -288,9 +288,8 @@ impl Ctx {
                 }
             }
             Expr::Ite(if_thens, else_) => {
-                let if_thens = if_thens.into_iter().rev();
                 let else_ = else_.map_or(Filter::Id, |else_| *get(*else_, self));
-                if_thens.fold(else_, |acc, (if_, then_)| {
+                if_thens.into_iter().rev().fold(else_, |acc, (if_, then_)| {
                     Filter::Ite(get(if_, self), get(then_, self), Box::new(acc))
                 })
             }

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -289,7 +289,8 @@ impl Ctx {
             }
             Expr::Ite(if_thens, else_) => {
                 let if_thens = if_thens.into_iter().rev();
-                if_thens.fold(*get(*else_, self), |acc, (if_, then_)| {
+                let else_ = else_.map_or(Filter::Id, |else_| *get(*else_, self));
+                if_thens.fold(else_, |acc, (if_, then_)| {
                     Filter::Ite(get(if_, self), get(then_, self), Box::new(acc))
                 })
             }

--- a/jaq-interpret/src/mir.rs
+++ b/jaq-interpret/src/mir.rs
@@ -344,7 +344,7 @@ impl Ctx {
                 let if_thens = if_thens
                     .into_iter()
                     .map(|(i, t)| (*get(i, self), *get(t, self)));
-                Filter::Ite(if_thens.collect(), get(*else_, self))
+                Filter::Ite(if_thens.collect(), else_.map(|else_| get(*else_, self)))
             }
             Expr::TryCatch(try_, catch_) => {
                 Filter::TryCatch(get(*try_, self), catch_.map(|c| get(*c, self)))

--- a/jaq-parse/src/filter.rs
+++ b/jaq-parse/src/filter.rs
@@ -21,7 +21,7 @@ where
     let else_ = just(Token::Else).ignore_then(filter.map(Box::new));
     if_.then(then.clone())
         .chain(elif.then(then).repeated())
-        .then(else_)
+        .then(else_.or_not())
         .then_ignore(just(Token::End))
         .map_with_span(|(if_thens, else_), span| (Filter::Ite(if_thens, else_), span))
 }

--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -33,7 +33,7 @@ def significand:
   elif . == 0.0 then 0.0
   else scalbln(.; ilogb | -1 * .) end;
 def pow10:            pow(10.0; .);
-def drem($l; r):      remainder($l; r) | if . == 0 then copysign(.; $l) else . end;
+def drem($l; r):      remainder($l; r) | if . == 0 then copysign(.; $l) end;
 def nexttoward(x; y): nextafter(x; y);
 def scalb(x; e):      x * pow(2.0; e);
 
@@ -116,7 +116,7 @@ def inside(xs): . as $x | xs | contains($x);
 def walk(f): def rec: (.[]? |= rec) | f; rec;
 
 def flatten: [recurse(arrays | .[]) | select(isarray | not)];
-def flatten($d): if $d > 0 then map(if isarray then flatten($d-1) else [.] end) | add else . end;
+def flatten($d): if $d > 0 then map(if isarray then flatten($d-1) else [.] end) | add end;
 
 # Regular expressions
 def capture_of_match: map(select(.name) | { (.name): .string} ) | add + {};

--- a/jaq-syn/src/filter.rs
+++ b/jaq-syn/src/filter.rs
@@ -122,7 +122,10 @@ pub enum Filter<C = String, V = String, Num = String> {
     /// Path such as `.`, `.a`, `.[][]."b"`
     Path(Box<Spanned<Self>>, Path<Self>),
     /// If-then-else
-    Ite(Vec<(Spanned<Self>, Spanned<Self>)>, Box<Spanned<Self>>),
+    Ite(
+        Vec<(Spanned<Self>, Spanned<Self>)>,
+        Option<Box<Spanned<Self>>>,
+    ),
     /// `reduce` and `foreach`, e.g. `reduce .[] as $x (0; .+$x)`
     ///
     /// The first field indicates whether to yield intermediate results


### PR DESCRIPTION
Quoth the jq manual:

> if A then B end is the same as if A then B else . end. That is, the else branch is optional, and if absent is the same as .. This also applies to elif with absent ending else branch.