### PR TITLE
Shrink error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
 name = "jaq-core"
 version = "1.0.0-beta"
 dependencies = [
+ "hifijson",
  "itertools",
  "jaq-interpret",
  "jaq-parse",

--- a/jaq-core/Cargo.toml
+++ b/jaq-core/Cargo.toml
@@ -10,12 +10,14 @@ repository = "https://github.com/01mf02/jaq"
 keywords = ["json", "query", "jq"]
 
 [features]
-default = ["std", "log", "math", "regex", "time"]
+default = ["std", "log", "math", "parse_json", "regex", "time"]
 std = []
 math = ["libm"]
+parse_json = ["hifijson"]
 
 [dependencies]
 jaq-interpret = { version = "1.0.0-beta", path = "../jaq-interpret" }
+hifijson = { version = "0.2.0", optional = true }
 time = { version = "0.3.22", optional = true, features = ["formatting", "parsing"] }
 regex = { version = "1.9", optional = true }
 log = { version = "0.4.17", optional = true }

--- a/jaq-core/src/math.rs
+++ b/jaq-core/src/math.rs
@@ -3,7 +3,7 @@ use jaq_interpret::{Error, Val};
 /// Use a value as an i32 to be given as an argument to a libm
 /// function.
 pub fn as_i32(v: &Val) -> Result<i32, Error> {
-    v.as_int()?.try_into().map_err(|_| Error::Int(v.clone()))
+    v.as_int()?.try_into().map_err(Error::from_str)
 }
 
 /// Build a 0-ary filter from a 1-ary math function.
@@ -44,10 +44,10 @@ pub(crate) use f_i;
 /// Build a filter from float to (float, int)
 macro_rules! f_fi {
     ($name: expr, $f: ident) => {
-        crate::math::math_0_ary!($name, $f, Val::as_float, |(x, y)| Val::arr(vec![
+        crate::math::math_0_ary!($name, $f, Val::as_float, |(x, y)| Val::arr(Vec::from([
             Val::Float(x),
             Val::Int(y as isize)
-        ]))
+        ])))
     };
     ($f: ident) => {
         crate::math::f_fi!(stringify!($f), $f)
@@ -59,10 +59,10 @@ pub(crate) use f_fi;
 /// Build a filter from float to (float, float)
 macro_rules! f_ff {
     ($name: expr, $f: ident) => {
-        crate::math::math_0_ary!($name, $f, Val::as_float, |(x, y)| Val::arr(vec![
+        crate::math::math_0_ary!($name, $f, Val::as_float, |(x, y)| Val::arr(Vec::from([
             Val::Float(x),
             Val::Float(y)
-        ]))
+        ])))
     };
     ($f: ident) => {
         crate::math::f_ff!(stringify!($f), $f)

--- a/jaq-core/src/regex.rs
+++ b/jaq-core/src/regex.rs
@@ -1,7 +1,7 @@
 //! Helpers to interface with the `regex` crate.
 
 use alloc::string::{String, ToString};
-use alloc::{rc::Rc, vec::Vec};
+use alloc::{format, rc::Rc, vec::Vec};
 use jaq_interpret::{Error, Val};
 
 #[derive(Default)]
@@ -136,8 +136,10 @@ impl From<Match> for Val {
 /// 1. output strings that do *not* match the regex, and
 /// 2. output the matches.
 pub fn regex(s: &str, re: &str, flags: &str, sm: (bool, bool)) -> Result<Vec<Val>, Error> {
-    let flags = Flags::new(flags).map_err(Error::RegexFlag)?;
-    let re = flags.regex(re).map_err(|e| Error::Regex(e.to_string()))?;
+    let fail_flag = |e| Error::from_str(format!("invalid regex flag: {e}"));
+    let fail_re = |e| Error::from_str(format!("invalid regex: {e}"));
+    let flags = Flags::new(flags).map_err(fail_flag)?;
+    let re = flags.regex(re).map_err(fail_re)?;
     let (split, matches) = sm;
 
     let mut last_byte = 0;

--- a/jaq-core/src/time.rs
+++ b/jaq-core/src/time.rs
@@ -8,7 +8,7 @@ pub fn from_iso8601(s: &str) -> ValR {
     use time::format_description::well_known::Iso8601;
     use time::OffsetDateTime;
     let datetime = OffsetDateTime::parse(s, &Iso8601::DEFAULT)
-        .map_err(|e| Error::Custom(format!("cannot parse {s} as ISO-8601 timestamp: {e}")))?;
+        .map_err(|e| Error::from_str(format!("cannot parse {s} as ISO-8601 timestamp: {e}")))?;
     let epoch_s = datetime.unix_timestamp();
     if s.contains('.') {
         let seconds = epoch_s as f64 + (datetime.nanosecond() as f64 * 1e-9_f64);
@@ -30,8 +30,8 @@ pub fn to_iso8601(v: &Val) -> Result<String, Error> {
         })
         .encode();
 
-    let fai1 = |e| Error::Custom(format!("cannot format {v} as ISO-8601 timestamp: {e}"));
-    let fai2 = |e| Error::Custom(format!("cannot format {v} as ISO-8601 timestamp: {e}"));
+    let fai1 = |e| Error::from_str(format!("cannot format {v} as ISO-8601 timestamp: {e}"));
+    let fai2 = |e| Error::from_str(format!("cannot format {v} as ISO-8601 timestamp: {e}"));
 
     match v {
         Val::Num(n) => to_iso8601(&Val::from_dec_str(n)),

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -3,7 +3,8 @@
 pub mod common;
 
 use common::{fail, give, gives};
-use jaq_interpret::{Error, Val};
+use jaq_interpret::error::{Error, Type};
+use jaq_interpret::{Val};
 use serde_json::json;
 
 yields!(nested_rec, "def f: def g: 0, g; g; def h: h; first(f)", 0);
@@ -48,7 +49,7 @@ fn explode_implode() {
     give(json!("❤ の"), "explode | implode", json!("❤ の"));
     give(json!("y̆"), "explode | implode", json!("y̆"));
 
-    fail(json!([1114112]), "implode", Error::Char(1114112));
+    //fail(json!([1114112]), "implode", Error::Char(1114112));
 }
 
 #[test]
@@ -71,13 +72,13 @@ fn group_by() {
 
 #[test]
 fn has() {
-    give(json!(null), "has(0)", json!(false));
-
-    let err = Error::Has(Val::Int(0), Val::Null);
-    fail(json!(0), "has([] | .[0])", err);
-    let err = Error::Has(Val::Int(0), Val::Int(1));
+    let err = Error::Index(Val::Null, Val::Int(0));
+    fail(json!(null), "has(0)", err);
+    let err = Error::Index(Val::Int(0), Val::Null);
+    fail(json!(0), "has([][0])", err);
+    let err = Error::Index(Val::Int(0), Val::Int(1));
     fail(json!(0), "has(1)", err);
-    let err = Error::Has(Val::Str("a".to_string().into()), Val::Int(0));
+    let err = Error::Index(Val::Str("a".to_string().into()), Val::Int(0));
     fail(json!("a"), "has(0)", err);
 
     give(json!([0, null]), "has(0)", json!(true));
@@ -104,8 +105,8 @@ fn keys_unsorted() {
     give(json!([0, null, "a"]), "keys_unsorted", json!([0, 1, 2]));
     give(json!({"a": 1, "b": 2}), "keys_unsorted", json!(["a", "b"]));
 
-    fail(json!(0), "keys_unsorted", Error::Keys(Val::Int(0)));
-    fail(json!(null), "keys_unsorted", Error::Keys(Val::Null));
+    fail(json!(0), "keys_unsorted", Error::Type(Val::Int(0), Type::Iter));
+    fail(json!(null), "keys_unsorted",Error::Type(Val::Null, Type::Iter));
 }
 
 #[test]
@@ -256,8 +257,8 @@ fn round() {
     give(json!(-1.4), "floor", json!(-2));
     give(json!(-1.4), "ceil", json!(-1));
 
-    fail(json!([]), "round", Error::Round(Val::from(json!([]))));
-    fail(json!({}), "round", Error::Round(Val::from(json!({}))));
+    fail(json!([]), "round", Error::Type(Val::from(json!([])), Type::Num));
+    fail(json!({}), "round", Error::Type(Val::from(json!({})), Type::Num));
 }
 
 #[test]

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -4,7 +4,7 @@ pub mod common;
 
 use common::{fail, give, gives};
 use jaq_interpret::error::{Error, Type};
-use jaq_interpret::{Val};
+use jaq_interpret::Val;
 use serde_json::json;
 
 yields!(nested_rec, "def f: def g: 0, g; g; def h: h; first(f)", 0);
@@ -49,7 +49,7 @@ fn explode_implode() {
     give(json!("❤ の"), "explode | implode", json!("❤ の"));
     give(json!("y̆"), "explode | implode", json!("y̆"));
 
-    //fail(json!([1114112]), "implode", Error::Char(1114112));
+    give(json!([1114112]), "try implode catch -1", json!(-1));
 }
 
 #[test]
@@ -105,8 +105,9 @@ fn keys_unsorted() {
     give(json!([0, null, "a"]), "keys_unsorted", json!([0, 1, 2]));
     give(json!({"a": 1, "b": 2}), "keys_unsorted", json!(["a", "b"]));
 
-    fail(json!(0), "keys_unsorted", Error::Type(Val::Int(0), Type::Iter));
-    fail(json!(null), "keys_unsorted",Error::Type(Val::Null, Type::Iter));
+    let err = |v| Error::Type(v, Type::Iter);
+    fail(json!(0), "keys_unsorted", err(Val::Int(0)));
+    fail(json!(null), "keys_unsorted", err(Val::Null));
 }
 
 #[test]
@@ -257,8 +258,9 @@ fn round() {
     give(json!(-1.4), "floor", json!(-2));
     give(json!(-1.4), "ceil", json!(-1));
 
-    fail(json!([]), "round", Error::Type(Val::from(json!([])), Type::Num));
-    fail(json!({}), "round", Error::Type(Val::from(json!({})), Type::Num));
+    let err = |v| Error::Type(Val::from(v), Type::Num);
+    fail(json!([]), "round", err(json!([])));
+    fail(json!({}), "round", err(json!({})));
 }
 
 #[test]

--- a/jaq-interpret/Cargo.toml
+++ b/jaq-interpret/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["compilers"]
 rust-version = "1.62"
 
 [features]
-default = ["std", "serde_json"]
+default = ["std", "hifijson", "serde_json"]
 std = []
 
 [dependencies]
 jaq-syn = { version = "1.0.0-beta", path = "../jaq-syn" }
 ahash = "0.7.6"
 dyn-clone = "1.0"
-hifijson = "0.2.0"
+hifijson = { version = "0.2.0", optional = true }
 indexmap = "2.0"
 itertools = "0.10.3"
 once_cell = "1.16.0"

--- a/jaq-interpret/src/error.rs
+++ b/jaq-interpret/src/error.rs
@@ -1,5 +1,6 @@
+//! Runtime errors.
 use crate::Val;
-use alloc::string::{String, ToString};
+use alloc::string::ToString;
 use core::fmt;
 
 /// Errors that can occur during filter execution.
@@ -8,52 +9,38 @@ use core::fmt;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
-    /// `inputs` (when given invalid JSON data)
-    Parse(String),
     /// `0 | error`
     Val(Val),
-    /// `[1114112] | implode`
-    Char(isize),
-    /// `{(0): 1}` or `0 | fromjson` or `0 | explode` or `"a b c" | split(0)`
-    Str(Val),
-    /// `0 | sort` or `0 | implode`
-    Arr(Val),
-    /// `0 == 0 | length`
-    Length(Val),
-    /// `"a" | round`
-    Round(Val),
-    /// `"[1, 2" | fromjson`
-    FromJson(Val, String),
-    /// `[] | has("a")` or `{} | has(0)`
-    Has(Val, Val),
-    /// `0 | keys`
-    Keys(Val),
-    /// `0 | .[]`
-    Iter(Val),
-    /// `-"a"`
-    Neg(Val),
+
+    Type(Val, Type),
     /// `1 - "a"`
     MathOp(Val, jaq_syn::MathOp, Val),
-    /// `0 | .[0]`
-    Index(Val),
-    /// `{} | .[0]`
-    IndexWith(Val, Val),
+    /// `{} | .[0]` or `[] | has("a")` or `{} | has(0)`
+    Index(Val, Val),
+
     /// `[] | .[0] = 0`
     IndexOutOfBounds(isize),
-    /// `[] | .["a"]` or `limit("a"; 0)` or `range(0; "a")`
-    Int(Val),
-    /// `"1" | sin` or `pow(2; "3")` or `fma(2; 3; "4")`
-    Float(Val),
-    /// `[] | .[0:] = 0`
-    SliceAssign(Val),
     /// `0 |= .+1`
     PathExp,
-    /// `"a" | test("(")`
-    Regex(String),
-    /// `"a" | test("."; "b")`
-    RegexFlag(char),
-    /// arbitrary errors for custom filters
-    Custom(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Type {
+    /// `[] | .["a"]` or `limit("a"; 0)` or `range(0; "a")`
+    Int,
+    /// `"1" | sin` or `pow(2; "3")` or `fma(2; 3; "4")`
+    Float,
+    /// `-"a"`, `"a" | round`
+    Num,
+    /// `{(0): 1}` or `0 | fromjson` or `0 | explode` or `"a b c" | split(0)`
+    Str,
+    /// `0 | sort` or `0 | implode` or `[] | .[0:] = 0`
+    Arr,
+    /// `0 | .[]` or `0 | .[0]` or `0 | keys`
+    Iter,
+
+    Range,
 }
 
 impl Error {
@@ -64,38 +51,39 @@ impl Error {
             _ => Val::str(self.to_string()),
         }
     }
+
+    pub fn from_str(s: impl ToString) -> Self {
+        Self::Val(Val::str(s.to_string()))
+    }
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Parse(s) => s.fmt(f),
             Self::Val(Val::Str(s)) => s.fmt(f),
             Self::Val(v) => v.fmt(f),
-            Self::Char(i) => write!(f, "cannot use {i} as character"),
-            Self::Str(v) => write!(f, "cannot use {v} as string"),
-            Self::Arr(v) => write!(f, "cannot use {v} as array"),
-            Self::Length(v) => write!(f, "{v} has no length"),
-            Self::Round(v) => write!(f, "cannot round {v}"),
-            Self::FromJson(v, why) => write!(f, "cannot parse {v} as JSON: {why}"),
-            Self::Keys(v) => write!(f, "{v} has no keys"),
-            Self::Has(v, k) => write!(f, "cannot check whether {v} has key {k}"),
-            Self::Iter(v) => write!(f, "cannot iterate over {v}"),
-            Self::Neg(v) => write!(f, "cannot negate {v}"),
+            Self::Type(v, ty) => write!(f, "cannot use {v} as {ty}"),
             Self::MathOp(l, op, r) => write!(f, "cannot calculate {l} {op} {r}"),
-            Self::Index(v) => write!(f, "cannot index {v}"),
-            Self::IndexWith(v, i) => write!(f, "cannot index {v} with {i}"),
+            Self::Index(v, i) => write!(f, "cannot index {v} with {i}"),
             Self::IndexOutOfBounds(i) => write!(f, "index {i} is out of bounds"),
-            Self::Int(v) => write!(f, "cannot use {v} as integer"),
-            Self::Float(v) => write!(f, "cannot use {v} as float"),
-            Self::SliceAssign(v) => write!(f, "cannot assign non-array ({v}) to an array slice"),
             Self::PathExp => write!(f, "invalid path expression"),
-            Self::Regex(e) => write!(f, "invalid regex: {e}"),
-            Self::RegexFlag(c) => write!(f, "invalid regex flag '{c}'"),
-            Self::Custom(e) => write!(f, "custom filter error: {e}"),
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Int => "integer".fmt(f),
+            Self::Float => "floating-point number".fmt(f),
+            Self::Num => "number".fmt(f),
+            Self::Str => "string".fmt(f),
+            Self::Arr => "array".fmt(f),
+            Self::Iter => "iterable (array or object)".fmt(f),
+            Self::Range => "rangeable (array or string)".fmt(f),
+        }
+    }
+}

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -46,7 +46,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-mod error;
+pub mod error;
 mod filter;
 mod lazy_iter;
 mod lir;

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -164,11 +164,13 @@ yields!(
     [0, 1, 2, 3]
 );
 yields!(try_without_catch, "[try (1,2,3[0],4)]", [1, 2, 4]);
+/*
 yields!(
     try_catch_prefix_operation,
     "try -[] catch .",
     "cannot negate []"
 );
+*/
 yields!(
     try_catch_postfix_operation,
     "[try 0[0]? catch .]",
@@ -178,6 +180,7 @@ yields!(
 // the inner try in these tests would resolve to empty and omit the
 // 1[1] error expression, and the whole expression would yield an
 // empty stream
+/*
 yields!(
     try_parsing_isnt_greedy_wrt_comma,
     "try (try 0[0], 1[1]) catch .",
@@ -193,6 +196,7 @@ yields!(
     "try (try 0 + 1[1]) catch .",
     "cannot index 1"
 );
+*/
 
 #[test]
 fn ord() {

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -164,39 +164,36 @@ yields!(
     [0, 1, 2, 3]
 );
 yields!(try_without_catch, "[try (1,2,3[0],4)]", [1, 2, 4]);
-/*
 yields!(
     try_catch_prefix_operation,
-    "try -[] catch .",
-    "cannot negate []"
+    r#"(try -[] catch .) | . > "" and . < []"#,
+    true
 );
-*/
 yields!(
     try_catch_postfix_operation,
     "[try 0[0]? catch .]",
     json!([])
 );
+
 // try should not gulp expressions after an infix operator; if it did,
 // the inner try in these tests would resolve to empty and omit the
 // 1[1] error expression, and the whole expression would yield an
 // empty stream
-/*
 yields!(
     try_parsing_isnt_greedy_wrt_comma,
-    "try (try 0[0], 1[1]) catch .",
-    "cannot index 1"
+    "try (try 0[0], 1[1]) catch . == try 1[1] catch .",
+    true
 );
 yields!(
     try_parsing_isnt_greedy_wrt_pipe,
-    "try (try 0 | 1[1]) catch .",
-    "cannot index 1"
+    "try (try 0 | 1[1]) catch . == try 1[1] catch .",
+    true
 );
 yields!(
     try_parsing_isnt_greedy_wrt_plus,
-    "try (try 0 + 1[1]) catch .",
-    "cannot index 1"
+    "try (try 0 + 1[1]) catch . == try 1[1] catch .",
+    true
 );
-*/
 
 #[test]
 fn ord() {


### PR DESCRIPTION
This PR reduces the size of the runtime error type by removing quite a few redundant variants.
In general, the aim is that only errors directly produced in jaq-interpret should have a dedicated variant in Error. All other custom errors produced in core should be serialized to strings via the new function `Error::from_str`.

One potential negative impact of this change is that error messages become less precise, but in the long term, it would be desirable anyway to store the location of errors.

Please note that I measured the impact of this change on performance, but I couldn't see any noticeable improvements. As an experiment, I also reduced the size of this error type even more by putting a `Box`  around the contents of the math and index variants (which store the most data), but as this also did not have any significant impact on performance, I did not commit this change.