### PR TITLE
Revert "Implement --nul-output"

### DIFF
--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -61,12 +61,6 @@ struct Cli {
     #[arg(short, long)]
     join_output: bool,
 
-    /// Print NUL after each value, instead of a newline
-    ///
-    /// Unlike jq, this does not enable `--raw-output`.
-    #[arg(short = '0', long)]
-    nul_output: bool,
-
     /// Color output
     #[arg(long, value_name = "WHEN", default_value = "auto")]
     color: Color,
@@ -458,9 +452,7 @@ fn print(cli: &Cli, val: Val, writer: &mut impl Write) -> io::Result<()> {
             }?
         }
     };
-    if cli.nul_output {
-        write!(writer, "\0")?
-    } else if !cli.join_output {
+    if !cli.join_output {
         writeln!(writer)?
     }
     Ok(())


### PR DESCRIPTION
Reverts 01mf02/jaq#91, because of #101.