### PR TITLE
String interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Here is an overview that summarises:
 - [x] if-then-else (`if .a < .b then .a else .b end`)
 - [x] Folding (`reduce .[] as $x (0; . + $x)`, `foreach .[] as $x (0; . + $x; . + .)`)
 - [x] Error handling (`try ... catch ...`) (see the [differences from jq](#error-handling))
-- [ ] String interpolation
+- [x] String interpolation (`"The successor of \(.) is \(.+1)."`)
 - [x] Format strings (`@json`, `@text`, `@csv`, `@tsv`, `@html`, `@sh`, `@base64`, `@base64d`)
 
 

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -26,6 +26,7 @@ pub enum Ast {
     #[default]
     Id,
     ToString,
+
     Int(isize),
     Float(f64),
     Str(String),

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -25,6 +25,7 @@ impl Owned {
 pub enum Ast {
     #[default]
     Id,
+    ToString,
     Int(isize),
     Float(f64),
     Str(String),
@@ -161,6 +162,7 @@ impl<'a> FilterT<'a> for Ref<'a> {
         let w = move |f: &'a Ast| Ref(f, self.1);
         match &self.0 {
             Ast::Id => box_once(Ok(cv.1)),
+            Ast::ToString => box_once(Ok(Val::str(cv.1.to_string_or_clone()))),
             Ast::Int(n) => box_once(Ok(Val::Int(*n))),
             Ast::Float(x) => box_once(Ok(Val::Float(*x))),
             Ast::Str(s) => box_once(Ok(Val::str(s.clone()))),
@@ -267,6 +269,7 @@ impl<'a> FilterT<'a> for Ref<'a> {
         let err = box_once(Err(Error::PathExp));
         let w = move |f: &'a Ast| Ref(f, self.1);
         match self.0 {
+            Ast::ToString => err,
             Ast::Int(_) | Ast::Float(_) | Ast::Str(_) => err,
             Ast::Array(_) | Ast::Object(_) => err,
             Ast::Neg(_) | Ast::Logic(..) | Ast::Math(..) | Ast::Ord(..) => err,

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -122,9 +122,9 @@ impl<'a> Ctx<'a> {
 
 impl ParseCtx {
     /// Given a main filter (consisting of definitions and a body), return a finished filter.
-    pub fn compile(&mut self, (defs, body): jaq_syn::Main) -> Filter {
-        self.insert_defs(defs);
-        self.root_filter(body);
+    pub fn compile(&mut self, main: jaq_syn::Main) -> Filter {
+        self.insert_defs(main.defs);
+        self.root_filter(main.body);
 
         if !self.errs.is_empty() {
             return Default::default();

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -143,8 +143,7 @@ impl Ctx {
     fn filter(&mut self, f: MirFilter, id: DefId, mut view: View, defs: &mir::Defs) -> Filter {
         let get = |f, ctx: &mut Self| Box::new(ctx.filter(f, id, view.clone(), defs));
         let of_str = |s: Str<_>, ctx: &mut Self| {
-            // TODO: call to_string_or_clone!
-            let fmt = s.fmt.map_or(Filter::Id, |fmt| *get(fmt, ctx));
+            let fmt = s.fmt.map_or(Filter::ToString, |fmt| *get(fmt, ctx));
             s.tail.into_iter().fold(Filter::Str(s.head), |acc, (f, s)| {
                 let add = |x, y| Filter::Math(Box::new(x), MathOp::Add, Box::new(y));
                 let f = Filter::Pipe(Box::new(*get(f, ctx)), false, Box::new(fmt.clone()));

--- a/jaq-interpret/src/mir.rs
+++ b/jaq-interpret/src/mir.rs
@@ -45,6 +45,7 @@ pub type Filter = jaq_syn::filter::Filter<Call, VarIdx, Num>;
 
 #[derive(Debug)]
 pub struct Def {
+    // TODO: convert name and args to Call
     pub name: String,
     pub args: Vec<Arg>,
     pub children: Vec<DefId>,
@@ -221,8 +222,8 @@ impl Ctx {
         // generate a fresh definition ID
         let id: DefId = self.defs.0.len();
         self.defs.0.push(Def {
-            name: def.call.name,
-            args: def.call.args,
+            name: def.lhs.name,
+            args: def.lhs.args,
             children: Vec::new(),
             ancestors: ancestors.clone(),
             // after MIR creation, we have to set all filters i with ctx.recursive[i] to defs[i].recursive
@@ -238,11 +239,11 @@ impl Ctx {
 
         ancestors.push(id);
 
-        for d in def.defs {
+        for d in def.rhs.defs {
             self.def(ancestors.clone(), d);
         }
 
-        self.defs.0[id].body = self.filter(id, Vec::new(), def.body);
+        self.defs.0[id].body = self.filter(id, Vec::new(), def.rhs.body);
     }
 
     fn filter(&mut self, id: DefId, mut vars: Vec<String>, f: HirFilter) -> MirFilter {

--- a/jaq-interpret/src/mir.rs
+++ b/jaq-interpret/src/mir.rs
@@ -330,7 +330,7 @@ impl Ctx {
                 self.errs.push((Error::Num(n), f.1.clone()));
                 n
             })),
-            Expr::Str(s) => Filter::Str(s),
+            Expr::Str(s) => Filter::Str(s.map(|f| *get(f, self))),
             Expr::Array(a) => Filter::Array(a.map(|a| get(*a, self))),
             Expr::Object(o) => {
                 Filter::Object(o.into_iter().map(|kv| kv.map(|f| *get(f, self))).collect())

--- a/jaq-interpret/src/mir.rs
+++ b/jaq-interpret/src/mir.rs
@@ -331,7 +331,7 @@ impl Ctx {
                 self.errs.push((Error::Num(n), f.1.clone()));
                 n
             })),
-            Expr::Str(s) => Filter::Str(s.map(|f| *get(f, self))),
+            Expr::Str(s) => Filter::Str(Box::new((*s).map(|f| *get(f, self)))),
             Expr::Array(a) => Filter::Array(a.map(|a| get(*a, self))),
             Expr::Object(o) => {
                 Filter::Object(o.into_iter().map(|kv| kv.map(|f| *get(f, self))).collect())

--- a/jaq-interpret/src/mir.rs
+++ b/jaq-interpret/src/mir.rs
@@ -221,8 +221,8 @@ impl Ctx {
         // generate a fresh definition ID
         let id: DefId = self.defs.0.len();
         self.defs.0.push(Def {
-            name: def.name,
-            args: def.args,
+            name: def.call.name,
+            args: def.call.args,
             children: Vec::new(),
             ancestors: ancestors.clone(),
             // after MIR creation, we have to set all filters i with ctx.recursive[i] to defs[i].recursive

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -105,6 +105,26 @@ fn precedence() {
     give(json!(null), "2 * 3 + 1", json!(7));
 }
 
+yields!(interpolation, r#"1 | "yields \(.+1)!""#, "yields 2!");
+// this diverges from jq, which yields ["2 2", "3 2", "2 4", "3 4"],
+// probably due to different order of evaluation addition
+yields!(
+    interpolation_many,
+    r#"2 | ["\(., .+1) \(., .*2)"]"#,
+    ["2 2", "2 4", "3 2", "3 4"]
+);
+// this does not work in jq, because jq does not allow for defining formatters
+yields!(
+    interpolation_fmt,
+    r#"def @say: "say " + .; @say "I \("disco"), you \("party")""#,
+    "I say disco, you say party"
+);
+yields!(
+    interpolation_nested,
+    r#""Here \("be \("nestings")")""#,
+    "Here be nestings"
+);
+
 yields!(
     obj_trailing_comma,
     "{a:1, b:2, c:3,}",

--- a/jaq-parse/src/def.rs
+++ b/jaq-parse/src/def.rs
@@ -8,19 +8,19 @@ fn def<P>(def: P) -> impl Parser<Token, Def, Error = Simple<Token>> + Clone
 where
     P: Parser<Token, Def, Error = Simple<Token>> + Clone,
 {
-    let arg = filter_map(|span, tok| match tok {
-        Token::Ident(name) => Ok(Arg::new_filter(name)),
-        Token::Var(name) => Ok(Arg::new_var(name)),
-        _ => Err(Simple::expected_input_found(span, Vec::new(), Some(tok))),
-    });
+    let arg = select! {
+        Token::Ident(name) => Arg::new_filter(name),
+        Token::Var(name) => Arg::new_var(name),
+    };
+
+    let defs = def.repeated().collect();
 
     just(Token::Def)
         .ignore_then(super::path::call(arg))
         .then_ignore(just(Token::Ctrl(':')))
-        .then(def.repeated().collect())
-        .then(filter())
+        .then(defs.then(filter()).map(|(defs, body)| Main { defs, body }))
         .then_ignore(just(Token::Ctrl(';')))
-        .map(|((call, defs), body)| Def { call, defs, body })
+        .map(|(lhs, rhs)| Def { lhs, rhs })
         .labelled("definition")
 }
 
@@ -31,5 +31,7 @@ pub fn defs() -> impl Parser<Token, Vec<Def>, Error = Simple<Token>> + Clone {
 
 /// Parser for a (potentially empty) sequence of definitions, followed by a filter.
 pub fn main() -> impl Parser<Token, Main, Error = Simple<Token>> + Clone {
-    defs().then(filter())
+    defs()
+        .then(filter())
+        .map(|(defs, body)| Main { defs, body })
 }

--- a/jaq-parse/src/def.rs
+++ b/jaq-parse/src/def.rs
@@ -1,7 +1,7 @@
 use super::{filter::filter, Token};
 use alloc::vec::Vec;
 use chumsky::prelude::*;
-use jaq_syn::{Arg, Def, Main, Call};
+use jaq_syn::{Arg, Call, Def, Main};
 
 /// A (potentially empty) parenthesised and `;`-separated sequence of arguments.
 fn args<T, P>(arg: P) -> impl Parser<Token, Vec<T>, Error = P::Error> + Clone

--- a/jaq-parse/src/filter.rs
+++ b/jaq-parse/src/filter.rs
@@ -105,7 +105,7 @@ where
 
     choice((
         parenthesised,
-        str_.map_with_span(|s, span| (Filter::Str(s), span)),
+        str_.map_with_span(|s, span| (Filter::from(s), span)),
         num.map_with_span(|num, span| (Filter::Num(num), span)),
         array.map_with_span(|arr, span| (Filter::Array(arr.map(Box::new)), span)),
         object.map_with_span(|obj, span| (Filter::Object(obj), span)),

--- a/jaq-parse/src/filter.rs
+++ b/jaq-parse/src/filter.rs
@@ -66,8 +66,8 @@ where
     }
     .labelled("number");
 
-    let str_ = super::path::str_(filter.clone());
-    let call = super::path::call(filter.clone());
+    let str_ = super::string::str_(filter.clone());
+    let call = super::def::call(filter.clone());
 
     // Atoms can also just be normal filters, but surrounded with parentheses
     let parenthesised = filter

--- a/jaq-parse/src/filter.rs
+++ b/jaq-parse/src/filter.rs
@@ -67,11 +67,7 @@ where
     .labelled("number");
 
     let str_ = super::path::str_(filter.clone());
-
-    let ident = select! {
-        Token::Ident(ident) => ident,
-    }
-    .labelled("identifier");
+    let call = super::path::call(filter.clone());
 
     // Atoms can also just be normal filters, but surrounded with parentheses
     let parenthesised = filter
@@ -100,8 +96,6 @@ where
         .delimited_by(just(Token::Ctrl('{')), just(Token::Ctrl('}')))
         .collect();
 
-    let call = ident.then(super::args(filter));
-
     let delim = |open, close| (Token::Ctrl(open), Token::Ctrl(close));
     let strategy = |open, close, others| {
         nested_delimiters(Token::Ctrl(open), Token::Ctrl(close), others, |span| {
@@ -115,7 +109,7 @@ where
         num.map_with_span(|num, span| (Filter::Num(num), span)),
         array.map_with_span(|arr, span| (Filter::Array(arr.map(Box::new)), span)),
         object.map_with_span(|obj, span| (Filter::Object(obj), span)),
-        call.map_with_span(|(f, args), span| (Filter::Call(f, args), span)),
+        call.map_with_span(|call, span| (Filter::from(call), span)),
         variable().map_with_span(|v, span| (Filter::Var(v), span)),
         recurse.map_with_span(|_, span| (Filter::Recurse, span)),
     ))

--- a/jaq-parse/src/lib.rs
+++ b/jaq-parse/src/lib.rs
@@ -35,13 +35,11 @@ where
 }
 
 fn lex() -> impl Parser<char, Vec<Spanned<Token>>, Error = Simple<char>> {
-    let comment = just("#").then(take_until(just('\n'))).padded();
-
-    token::token()
-        .padded_by(comment.repeated())
-        .map_with_span(|tok, span| (tok, span))
-        .padded()
+    recursive(token::tree)
+        .map_with_span(|tree, span| tree.tokens(span))
         .repeated()
+        .flatten()
+        .collect()
 }
 
 /// Parse a string with a given parser.

--- a/jaq-parse/src/lib.rs
+++ b/jaq-parse/src/lib.rs
@@ -9,8 +9,8 @@ mod def;
 mod filter;
 mod path;
 mod prec_climb;
-mod token;
 mod string;
+mod token;
 
 use jaq_syn as syn;
 

--- a/jaq-parse/src/lib.rs
+++ b/jaq-parse/src/lib.rs
@@ -10,6 +10,7 @@ mod filter;
 mod path;
 mod prec_climb;
 mod token;
+mod string;
 
 use jaq_syn as syn;
 
@@ -22,17 +23,6 @@ use syn::Spanned;
 
 /// Lex/parse error.
 pub type Error = Simple<String>;
-
-/// A (potentially empty) parenthesised and `;`-separated sequence of arguments.
-fn args<T, P>(arg: P) -> impl Parser<Token, Vec<T>, Error = P::Error> + Clone
-where
-    P: Parser<Token, T> + Clone,
-{
-    arg.separated_by(just(Token::Ctrl(';')))
-        .delimited_by(just(Token::Ctrl('(')), just(Token::Ctrl(')')))
-        .or_not()
-        .map(Option::unwrap_or_default)
-}
 
 fn lex() -> impl Parser<char, Vec<Spanned<Token>>, Error = Simple<char>> {
     recursive(token::tree)

--- a/jaq-parse/src/path.rs
+++ b/jaq-parse/src/path.rs
@@ -1,7 +1,7 @@
 use super::Token;
 use chumsky::prelude::*;
-use jaq_syn::path::{Opt, Part, Path, Str};
-use jaq_syn::{Call, Spanned};
+use jaq_syn::path::{Opt, Part, Path};
+use jaq_syn::{Call, Spanned, Str};
 
 fn opt() -> impl Parser<Token, Opt, Error = Simple<Token>> + Clone {
     just(Token::Ctrl('?')).or_not().map(|q| match q {
@@ -28,18 +28,26 @@ where
     P: Parser<Token, Spanned<T>, Error = Simple<Token>> + Clone,
 {
     //.filter(|fmt| fmt.name.starts_with('@'));
-    let fmt = call(expr.clone()).map_with_span(|x, span| (T::from(x), span));
+    let fmt = call(expr.clone()).map_with_span(|x, span| ((T::from(x), span)).into());
 
     let parenthesised = expr.delimited_by(just(Token::Ctrl('(')), just(Token::Ctrl(')')));
 
     let chars = select! {
         Token::Str(s) => s,
     };
-    fmt.or_not()
-        .then(chars)
+    let parts = chars
         .then(parenthesised.then(chars).repeated())
-        .delimited_by(just(Token::Quote), just(Token::Quote))
-        .map(|((fmt, head), tail)| Str { fmt, head, tail })
+        .map(|(head, tail)| {
+            use core::iter::once;
+            use jaq_syn::string::Part;
+            let tail = tail
+                .into_iter()
+                .flat_map(|(f, s)| [Part::Fun(f), Part::Str(s)]);
+            once(Part::Str(head)).chain(tail).collect()
+        });
+    fmt.or_not()
+        .then(parts.delimited_by(just(Token::Quote), just(Token::Quote)))
+        .map(|(fmt, parts)| Str { fmt, parts })
         .labelled("string")
 }
 

--- a/jaq-parse/src/string.rs
+++ b/jaq-parse/src/string.rs
@@ -7,8 +7,14 @@ where
     T: From<Call<Spanned<T>>>,
     P: Parser<Token, Spanned<T>, Error = Simple<Token>> + Clone,
 {
-    //.filter(|fmt| fmt.name.starts_with('@'));
-    let fmt = super::def::call(expr.clone()).map_with_span(|x, span| ((T::from(x), span)).into());
+    let call = |name| Call {
+        name,
+        args: Default::default(),
+    };
+    let ident = select! {
+        Token::Ident(ident) if ident.starts_with('@') => ident,
+    };
+    let fmt = ident.map_with_span(move |x, span| ((T::from(call(x)), span)).into());
 
     let parenthesised = expr.delimited_by(just(Token::Ctrl('(')), just(Token::Ctrl(')')));
 

--- a/jaq-parse/src/string.rs
+++ b/jaq-parse/src/string.rs
@@ -14,7 +14,7 @@ where
     let ident = select! {
         Token::Ident(ident) if ident.starts_with('@') => ident,
     };
-    let fmt = ident.map_with_span(move |x, span| ((T::from(call(x)), span)).into());
+    let fmt = ident.map_with_span(move |x, span| (T::from(call(x)), span).into());
 
     let parenthesised = expr.delimited_by(just(Token::Ctrl('(')), just(Token::Ctrl(')')));
 

--- a/jaq-parse/src/string.rs
+++ b/jaq-parse/src/string.rs
@@ -1,0 +1,33 @@
+use super::Token;
+use chumsky::prelude::*;
+use jaq_syn::{Call, Spanned, Str};
+
+pub fn str_<T, P>(expr: P) -> impl Parser<Token, Str<Spanned<T>>, Error = P::Error> + Clone
+where
+    T: From<Call<Spanned<T>>>,
+    P: Parser<Token, Spanned<T>, Error = Simple<Token>> + Clone,
+{
+    //.filter(|fmt| fmt.name.starts_with('@'));
+    let fmt = super::def::call(expr.clone()).map_with_span(|x, span| ((T::from(x), span)).into());
+
+    let parenthesised = expr.delimited_by(just(Token::Ctrl('(')), just(Token::Ctrl(')')));
+
+    let chars = select! {
+        Token::Str(s) => s,
+    };
+    let parts = chars
+        .then(parenthesised.then(chars).repeated())
+        .map(|(head, tail)| {
+            use core::iter::once;
+            use jaq_syn::string::Part;
+            let tail = tail
+                .into_iter()
+                .flat_map(|(f, s)| [Part::Fun(f), Part::Str(s)]);
+            once(Part::Str(head)).chain(tail).collect()
+        });
+    fmt.or_not()
+        .then(parts.delimited_by(just(Token::Quote), just(Token::Quote)))
+        .map(|(fmt, parts)| Str { fmt, parts })
+        .labelled("string")
+}
+

--- a/jaq-parse/src/string.rs
+++ b/jaq-parse/src/string.rs
@@ -15,19 +15,16 @@ where
     let chars = select! {
         Token::Str(s) => s,
     };
-    let parts = chars
-        .then(parenthesised.then(chars).repeated())
-        .map(|(head, tail)| {
-            use core::iter::once;
-            use jaq_syn::string::Part;
-            let tail = tail
-                .into_iter()
-                .flat_map(|(f, s)| [Part::Fun(f), Part::Str(s)]);
-            once(Part::Str(head)).chain(tail).collect()
-        });
+    let parts = chars.then(parenthesised.then(chars).repeated());
+    let parts = parts.map(|(head, tail)| {
+        use core::iter::once;
+        use jaq_syn::string::Part::{Fun, Str};
+        let tail = tail.into_iter().flat_map(|(f, s)| [Fun(f), Str(s)]);
+        let parts = once(Str(head)).chain(tail);
+        parts.filter(|p| !p.is_empty()).collect()
+    });
     fmt.or_not()
         .then(parts.delimited_by(just(Token::Quote), just(Token::Quote)))
         .map(|(fmt, parts)| Str { fmt, parts })
         .labelled("string")
 }
-

--- a/jaq-parse/src/token.rs
+++ b/jaq-parse/src/token.rs
@@ -46,9 +46,11 @@ impl Tree {
                 let tokens = tree.into_iter().flat_map(|(t, s)| t.tokens(s));
                 Box::new(once(s).chain(tokens).chain(once(e)))
             }
-            Self::String(s, _interpol) => {
-                let s = (Token::Str(s.0), s.1);
-                Box::new(once(s))
+            Self::String(head, _interpol) => {
+                let s = (Token::Quote, span.start..span.start + 1);
+                let e = (Token::Quote, span.end - 1..span.end);
+                let head = (Token::Str(head.0), head.1);
+                Box::new(once(s).chain(once(head)).chain(once(e)))
             }
         }
     }
@@ -62,6 +64,7 @@ pub enum Token {
     Ident(String),
     Var(String),
     Ctrl(char),
+    Quote,
     DotDot,
     Dot,
     Def,
@@ -86,6 +89,7 @@ impl fmt::Display for Token {
             Self::Num(s) | Self::Str(s) | Self::Op(s) | Self::Ident(s) => s.fmt(f),
             Self::Var(s) => write!(f, "${s}"),
             Self::Ctrl(c) => c.fmt(f),
+            Self::Quote => '"'.fmt(f),
             Self::DotDot => "..".fmt(f),
             Self::Dot => ".".fmt(f),
             Self::Def => "def".fmt(f),

--- a/jaq-std/build.rs
+++ b/jaq-std/build.rs
@@ -7,7 +7,9 @@ fn main() {
     let buffer = std::fs::File::create(dest_path).unwrap();
 
     let std = include_str!("src/std.jq");
-    let std = jaq_parse::parse(std, jaq_parse::defs()).0.unwrap();
+    let (std, errs) = jaq_parse::parse(std, jaq_parse::defs());
+    assert_eq!(errs, Vec::new());
+    let std = std.unwrap();
     bincode::serialize_into(buffer, &std).unwrap();
 }
 

--- a/jaq-syn/src/def.rs
+++ b/jaq-syn/src/def.rs
@@ -4,6 +4,7 @@ use alloc::{string::String, vec::Vec};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// Call to a filter identified by a name type `N` with arguments of type `A`.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Call<A, N = String> {
@@ -14,6 +15,7 @@ pub struct Call<A, N = String> {
 }
 
 impl<A, N> Call<A, N> {
+    /// Apply a function to the call arguments.
     pub fn map_args<B>(self, f: impl FnMut(A) -> B) -> Call<B, N> {
         Call {
             name: self.name,
@@ -26,7 +28,9 @@ impl<A, N> Call<A, N> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Def {
+    /// left-hand side, i.e. what shall be defined, e.g. `map(f)`
     pub lhs: Call<Arg>,
+    /// right-hand side, i.e. what the LHS should be defined as, e.g. `[.[] | f]`
     pub rhs: Main,
 }
 

--- a/jaq-syn/src/def.rs
+++ b/jaq-syn/src/def.rs
@@ -4,14 +4,29 @@ use alloc::{string::String, vec::Vec};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+pub struct Call<A, N = String> {
+    /// Name of the filter, e.g. `map`
+    pub name: N,
+    /// Arguments of the filter, e.g. `["f"]`
+    pub args: Vec<A>,
+}
+
+impl<A, N> Call<A, N> {
+    pub fn map_args<B>(self, f: impl FnMut(A) -> B) -> Call<B, N> {
+        Call {
+            name: self.name,
+            args: self.args.into_iter().map(f).collect(),
+        }
+    }
+}
+
 /// A definition, such as `def map(f): [.[] | f];`.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Def {
-    /// Name of the filter, e.g. `map`
-    pub name: String,
-    /// Arguments of the filter, e.g. `["f"]`
-    pub args: Vec<Arg>,
+    pub call: Call<Arg>,
     /// Definitions at the top of the filter
     pub defs: Vec<Self>,
     /// Body of the filter, e.g. `[.[] | f`.

--- a/jaq-syn/src/def.rs
+++ b/jaq-syn/src/def.rs
@@ -26,11 +26,8 @@ impl<A, N> Call<A, N> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Def {
-    pub call: Call<Arg>,
-    /// Definitions at the top of the filter
-    pub defs: Vec<Self>,
-    /// Body of the filter, e.g. `[.[] | f`.
-    pub body: Spanned<Filter>,
+    pub lhs: Call<Arg>,
+    pub rhs: Main,
 }
 
 /// Argument of a definition, such as `$v` or `f` in `def foo($v; f): ...`.
@@ -68,6 +65,12 @@ impl Arg {
     }
 }
 
-// TODO: rename to Body?
 /// (Potentially empty) sequence of definitions, followed by a filter.
-pub type Main = (Vec<Def>, Spanned<Filter>);
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug)]
+pub struct Main {
+    /// Definitions at the top of the filter
+    pub defs: Vec<Def>,
+    /// Body of the filter, e.g. `[.[] | f`.
+    pub body: Spanned<Filter>,
+}

--- a/jaq-syn/src/filter.rs
+++ b/jaq-syn/src/filter.rs
@@ -1,5 +1,5 @@
 //! Functions from values to streams of values.
-use crate::{MathOp, OrdOp, Path, Span, Spanned};
+use crate::{MathOp, OrdOp, Path, Span, Spanned, Str};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 #[cfg(feature = "serde")]
@@ -60,7 +60,7 @@ pub enum KeyVal<T> {
     Filter(T, T),
     /// Key is a string, and value is an optional filter, e.g. `{a: 1, b}`
     /// (this is equivalent to `{("a"): 1, ("b"): .b}`)
-    Str(String, Option<T>),
+    Str(Str<T>, Option<T>),
 }
 
 impl<F> KeyVal<F> {
@@ -68,7 +68,7 @@ impl<F> KeyVal<F> {
     pub fn map<G>(self, mut f: impl FnMut(F) -> G) -> KeyVal<G> {
         match self {
             Self::Filter(k, v) => KeyVal::Filter(f(k), f(v)),
-            Self::Str(k, v) => KeyVal::Str(k, v.map(f)),
+            Self::Str(k, v) => KeyVal::Str(k.map(&mut f), v.map(f)),
         }
     }
 }
@@ -111,7 +111,7 @@ pub enum Filter<C = String, V = String, Num = String> {
     /// Integer or floating-point number.
     Num(Num),
     /// String
-    Str(String),
+    Str(Str<Spanned<Self>>),
     /// Array, empty if `None`
     Array(Option<Box<Spanned<Self>>>),
     /// Object, specifying its key-value pairs
@@ -143,8 +143,8 @@ pub enum Filter<C = String, V = String, Num = String> {
     Binary(Box<Spanned<Self>>, BinaryOp, Box<Spanned<Self>>),
 }
 
-impl From<String> for Filter {
-    fn from(s: String) -> Self {
+impl From<Str<Spanned<Filter>>> for Filter {
+    fn from(s: Str<Spanned<Filter>>) -> Self {
         Self::Str(s)
     }
 }

--- a/jaq-syn/src/filter.rs
+++ b/jaq-syn/src/filter.rs
@@ -1,5 +1,5 @@
 //! Functions from values to streams of values.
-use crate::{MathOp, OrdOp, Path, Span, Spanned, Str};
+use crate::{Call, MathOp, OrdOp, Path, Span, Spanned, Str};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 #[cfg(feature = "serde")]
@@ -146,6 +146,12 @@ pub enum Filter<C = String, V = String, Num = String> {
 impl From<Str<Spanned<Filter>>> for Filter {
     fn from(s: Str<Spanned<Filter>>) -> Self {
         Self::Str(s)
+    }
+}
+
+impl From<Call<Spanned<Filter>>> for Filter {
+    fn from(c: Call<Spanned<Filter>>) -> Self {
+        Self::Call(c.name, c.args)
     }
 }
 

--- a/jaq-syn/src/filter.rs
+++ b/jaq-syn/src/filter.rs
@@ -111,7 +111,7 @@ pub enum Filter<C = String, V = String, Num = String> {
     /// Integer or floating-point number.
     Num(Num),
     /// String
-    Str(Str<Spanned<Self>>),
+    Str(Box<Str<Spanned<Self>>>),
     /// Array, empty if `None`
     Array(Option<Box<Spanned<Self>>>),
     /// Object, specifying its key-value pairs
@@ -145,7 +145,7 @@ pub enum Filter<C = String, V = String, Num = String> {
 
 impl From<Str<Spanned<Filter>>> for Filter {
     fn from(s: Str<Spanned<Filter>>) -> Self {
-        Self::Str(s)
+        Self::Str(Box::new(s))
     }
 }
 

--- a/jaq-syn/src/lib.rs
+++ b/jaq-syn/src/lib.rs
@@ -15,7 +15,8 @@ pub use def::{Arg, Def, Main};
 pub use ops::{MathOp, OrdOp};
 use path::Path;
 
-type Span = core::ops::Range<usize>;
+/// Position information.
+pub type Span = core::ops::Range<usize>;
 
 /// An object with position information.
 pub type Spanned<T> = (T, Span);

--- a/jaq-syn/src/lib.rs
+++ b/jaq-syn/src/lib.rs
@@ -9,11 +9,13 @@ mod def;
 pub mod filter;
 mod ops;
 pub mod path;
+pub mod string;
 pub mod test;
 
 pub use def::{Arg, Call, Def, Main};
 pub use ops::{MathOp, OrdOp};
-use path::{Path, Str};
+use path::Path;
+pub use string::Str;
 
 /// Position information.
 pub type Span = core::ops::Range<usize>;

--- a/jaq-syn/src/lib.rs
+++ b/jaq-syn/src/lib.rs
@@ -11,7 +11,7 @@ mod ops;
 pub mod path;
 pub mod test;
 
-pub use def::{Arg, Def, Main};
+pub use def::{Arg, Call, Def, Main};
 pub use ops::{MathOp, OrdOp};
 use path::{Path, Str};
 

--- a/jaq-syn/src/lib.rs
+++ b/jaq-syn/src/lib.rs
@@ -13,7 +13,7 @@ pub mod test;
 
 pub use def::{Arg, Def, Main};
 pub use ops::{MathOp, OrdOp};
-use path::Path;
+use path::{Path, Str};
 
 /// Position information.
 pub type Span = core::ops::Range<usize>;

--- a/jaq-syn/src/path.rs
+++ b/jaq-syn/src/path.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct Str<T> {
     /// optional filter that is applied to the output of interpolated filters
     /// (`tostring` if not given)
-    pub fmt: Option<Call<T>>,
+    pub fmt: Option<T>,
     /// the longest prefix of the string until the first interpolation
     pub head: String,
     /// sequence of interpolated filters followed by strings
@@ -21,7 +21,7 @@ impl<T> Str<T> {
     /// Apply a function to the interpolated filters.
     pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> Str<U> {
         Str {
-            fmt: self.fmt.map(|fmt| fmt.map_args(&mut f)),
+            fmt: self.fmt.map(&mut f),
             head: self.head,
             tail: self.tail.into_iter().map(|(x, s)| (f(x), s)).collect(),
         }

--- a/jaq-syn/src/path.rs
+++ b/jaq-syn/src/path.rs
@@ -1,41 +1,7 @@
 //! Value access and iteration.
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
-/// A possibly interpolated string.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
-pub struct Str<T> {
-    /// optional filter that is applied to the output of interpolated filters
-    /// (`tostring` if not given)
-    pub fmt: Option<T>,
-    /// the longest prefix of the string until the first interpolation
-    pub head: String,
-    /// sequence of interpolated filters followed by strings
-    pub tail: Vec<(T, String)>,
-}
-
-impl<T> Str<T> {
-    /// Apply a function to the interpolated filters.
-    pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> Str<U> {
-        Str {
-            fmt: self.fmt.map(&mut f),
-            head: self.head,
-            tail: self.tail.into_iter().map(|(x, s)| (f(x), s)).collect(),
-        }
-    }
-}
-
-impl<T> From<String> for Str<T> {
-    fn from(head: String) -> Self {
-        Self {
-            fmt: None,
-            head,
-            tail: Vec::new(),
-        }
-    }
-}
 
 /// A path such as `.[].a?[1:]`.
 pub type Path<T> = Vec<(Part<crate::Spanned<T>>, Opt)>;

--- a/jaq-syn/src/path.rs
+++ b/jaq-syn/src/path.rs
@@ -1,5 +1,4 @@
 //! Value access and iteration.
-use crate::Call;
 use alloc::{string::String, vec::Vec};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/jaq-syn/src/string.rs
+++ b/jaq-syn/src/string.rs
@@ -1,4 +1,4 @@
-/// Interpolated strings.
+//! Interpolated strings.
 use alloc::{boxed::Box, string::String, vec::Vec};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/jaq-syn/src/string.rs
+++ b/jaq-syn/src/string.rs
@@ -1,5 +1,4 @@
 /// Interpolated strings.
-
 use alloc::{boxed::Box, string::String, vec::Vec};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -20,6 +19,14 @@ impl<T> Part<T> {
         match self {
             Self::Str(s) => Part::Str(s),
             Self::Fun(x) => Part::Fun(f(x)),
+        }
+    }
+
+    /// Returns true if the part is an empty constant string.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Str(s) if s.is_empty() => true,
+            _ => false,
         }
     }
 }

--- a/jaq-syn/src/string.rs
+++ b/jaq-syn/src/string.rs
@@ -25,8 +25,8 @@ impl<T> Part<T> {
     /// Returns true if the part is an empty constant string.
     pub fn is_empty(&self) -> bool {
         match self {
-            Self::Str(s) if s.is_empty() => true,
-            _ => false,
+            Self::Str(s) => s.is_empty(),
+            Self::Fun(_) => false,
         }
     }
 }

--- a/jaq-syn/src/string.rs
+++ b/jaq-syn/src/string.rs
@@ -1,0 +1,55 @@
+/// Interpolated strings.
+
+use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// A part of an interpolated string.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+pub enum Part<T> {
+    /// constant string
+    Str(String),
+    /// interpolated filter
+    Fun(T),
+}
+
+impl<T> Part<T> {
+    /// Apply a function to the contained filters.
+    pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> Part<U> {
+        match self {
+            Self::Str(s) => Part::Str(s),
+            Self::Fun(x) => Part::Fun(f(x)),
+        }
+    }
+}
+
+/// A possibly interpolated string.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+pub struct Str<T> {
+    /// optional filter that is applied to the output of interpolated filters
+    /// (`tostring` if not given)
+    pub fmt: Option<Box<T>>,
+    /// sequence of strings and interpolated filters
+    pub parts: Vec<Part<T>>,
+}
+
+impl<T> Str<T> {
+    /// Apply a function to the contained filters.
+    pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> Str<U> {
+        Str {
+            fmt: self.fmt.map(|fmt| Box::new(f(*fmt))),
+            parts: self.parts.into_iter().map(|p| p.map(&mut f)).collect(),
+        }
+    }
+}
+
+impl<T> From<String> for Str<T> {
+    fn from(s: String) -> Self {
+        Self {
+            fmt: None,
+            parts: Vec::from([Part::Str(s)]),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for string interpolation, such as `"The successor of \(.) is \(.+1)."`
It also allows prefixing formatters, allowing for things like `@uri "https://www.google.com/search?q=\(.search)"`.

Unlike jq, jaq allows the definition of n-ary filters starting with an `@`.
However, like jq, jaq limits the usage of formatters usable in string interpolation to nullary filters starting with an `@`. This restriction simplifies the parser, which might otherwise run into exponential runtime issues.