### PR TITLE
Restore `sub` branching

### DIFF
--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -129,8 +129,10 @@ def capture(re; flags): matches(re; flags)[] | capture_of_match;
 def split (re; flags): split_(re; flags + "g");
 def splits(re; flags): split(re; flags)[];
 
-def sub(re; f; flags): reduce split_matches(re; flags)[] as $x
-  (""; . + if $x | isstring then $x else $x | capture_of_match | f end);
+def sub(re; f; flags):
+  def handle: if isarray then capture_of_match | f end;
+  reduce split_matches(re; flags)[] as $x (""; . + ($x | handle));
+
 def gsub(re; f; flags): sub(re; f; "g" + flags);
 
 def    test(re):    test(re; "");

--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -129,8 +129,8 @@ def capture(re; flags): matches(re; flags)[] | capture_of_match;
 def split (re; flags): split_(re; flags + "g");
 def splits(re; flags): split(re; flags)[];
 
-def sub(re; f; flags): split_matches(re; flags) |
-  map(if isstring then . else capture_of_match | f end) | add;
+def sub(re; f; flags): reduce split_matches(re; flags)[] as $x
+  (""; . + if $x | isstring then $x else $x | capture_of_match | f end);
 def gsub(re; f; flags): sub(re; f; "g" + flags);
 
 def    test(re):    test(re; "");

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -388,10 +388,8 @@ yields!(
     r#""XYxyXYxy" | gsub("(?<upper>[A-Z])(?<lower>[a-z])"; .lower + .upper)"#,
     "XxYyXxYy"
 );
-/*
 yields!(
     gsub_many,
     r#""XxYy" | [gsub("(?<upper>[A-Z])"; .upper, "!" + .upper)]"#,
     ["XxYy", "Xx!Yy", "!XxYy", "!Xx!Yy"]
 );
-*/

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -378,23 +378,20 @@ fn while_until() {
     );
 }
 
+yields!(sub, r#""XYxyXYxy" | sub("x";"Q")"#, "XYQyXYxy");
+yields!(gsub, r#""XYxyXYxy" | gsub("x";"Q")"#, "XYQyXYQy");
+yields!(isub, r#""XYxyXYxy" | sub("x";"Q";"i")"#, "QYxyXYxy");
+yields!(gisub, r#""XYxyXYxy" | gsub("x";"Q";"i")"#, "QYQyQYQy");
+// swap adjacent occurrences of upper- and lower-case characters
 yields!(
-    sub,
-    r#""XYZxyzXYZxyz" | sub("x";"Q")"#,
-    json!("XYZQyzXYZxyz")
+    gsub_swap,
+    r#""XYxyXYxy" | gsub("(?<upper>[A-Z])(?<lower>[a-z])"; .lower + .upper)"#,
+    "XxYyXxYy"
 );
+/*
 yields!(
-    sub_flags,
-    r#""XYZxyzXYZxyz" | sub("x";"Q";"i")"#,
-    json!("QYZxyzXYZxyz")
+    gsub_many,
+    r#""XxYy" | [gsub("(?<upper>[A-Z])"; .upper, "!" + .upper)]"#,
+    ["XxYy", "Xx!Yy", "!XxYy", "!Xx!Yy"]
 );
-yields!(
-    gsub,
-    r#""XYZxyzXYZxyz" | gsub("x";"Q")"#,
-    json!("XYZQyzXYZQyz")
-);
-yields!(
-    gsub_flags,
-    r#""XYZxyzXYZxyz" | gsub("x";"Q";"i")"#,
-    json!("QYZQyzQYZQyz")
-);
+*/

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -388,6 +388,7 @@ yields!(
     r#""XYxyXYxy" | gsub("(?<upper>[A-Z])(?<lower>[a-z])"; .lower + .upper)"#,
     "XxYyXxYy"
 );
+// this diverges from jq, which yields ["XxYy", "!XxYy", "Xx!Yy", "!Xx!Yy"]
 yields!(
     gsub_many,
     r#""XxYy" | [gsub("(?<upper>[A-Z])"; .upper, "!" + .upper)]"#,


### PR DESCRIPTION
0d402245692e8f2a5f52fcb48297ecc89caeaa02 broke the branching behaviour of `sub`.
This PR restores it, and adds a test to ensure it does not fail again.