### PR TITLE
Lazy cartesian products

### DIFF
--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -194,6 +194,11 @@ fn limit() {
     give(json!(null), "[limit(-1; 0, 1)]", json!([]));
 }
 
+// the following tests show that sums are evaluated lazily
+// (otherwise this would not terminate)
+yields!(limit_inf_suml, "[limit(3; recurse(.+1) + 0)]", [0, 1, 2]);
+yields!(limit_inf_sumr, "[limit(3; 0 + recurse(.+1))]", [0, 1, 2]);
+
 yields!(min_empty, "[] | min_by(.)", json!(null));
 // when output is equal, min_by selects the left element and max_by the right one
 yields!(

--- a/jaq-interpret/src/box_iter.rs
+++ b/jaq-interpret/src/box_iter.rs
@@ -1,0 +1,29 @@
+use alloc::boxed::Box;
+
+pub type BoxIter<'a, T> = Box<dyn Iterator<Item = T> + 'a>;
+
+/// Return a boxed iterator that yields a single element.
+pub fn box_once<'a, T: 'a>(x: T) -> BoxIter<'a, T> {
+    Box::new(core::iter::once(x))
+}
+
+/// For every element `y` returned by `l`, return the output of `r(y, x)`.
+///
+/// In case that `l` returns only a single element, this does not clone `x`.
+pub fn flat_map_with<'a, T: Clone + 'a, U: 'a, V: 'a>(
+    mut l: impl Iterator<Item = U> + 'a,
+    x: T,
+    r: impl Fn(U, T) -> BoxIter<'a, V> + 'a,
+) -> BoxIter<'a, V> {
+    // this special case is to avoid cloning `x`
+    if l.size_hint().1 == Some(1) {
+        if let Some(ly) = l.next() {
+            // the Rust documentation states that
+            // "a buggy iterator may yield [..] more than the upper bound of elements",
+            // but so far, it seems that all iterators here are not buggy :)
+            assert!(l.next().is_none());
+            return Box::new(r(ly, x));
+        }
+    }
+    Box::new(l.flat_map(move |ly| r(ly, x.clone())))
+}

--- a/jaq-interpret/src/box_iter.rs
+++ b/jaq-interpret/src/box_iter.rs
@@ -10,6 +10,27 @@ pub fn box_once<'a, T: 'a>(x: T) -> BoxIter<'a, T> {
 /// For every element `y` returned by `l`, return the output of `r(y, x)`.
 ///
 /// In case that `l` returns only a single element, this does not clone `x`.
+pub fn map_with<'a, T: Clone + 'a, U: 'a, V: 'a>(
+    mut l: impl Iterator<Item = U> + 'a,
+    x: T,
+    r: impl Fn(U, T) -> V + 'a,
+) -> BoxIter<'a, V> {
+    // this special case is to avoid cloning `x`
+    if l.size_hint().1 == Some(1) {
+        if let Some(ly) = l.next() {
+            // the Rust documentation states that
+            // "a buggy iterator may yield [..] more than the upper bound of elements",
+            // but so far, it seems that all iterators here are not buggy :)
+            assert!(l.next().is_none());
+            return box_once(r(ly, x));
+        }
+    }
+    Box::new(l.map(move |ly| r(ly, x.clone())))
+}
+
+/// For every element `y` returned by `l`, return the outputs of `r(y, x)`.
+///
+/// In case that `l` returns only a single element, this does not clone `x`.
 pub fn flat_map_with<'a, T: Clone + 'a, U: 'a, V: 'a>(
     mut l: impl Iterator<Item = U> + 'a,
     x: T,

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -1,5 +1,6 @@
+use crate::box_iter::box_once;
 use crate::path::{self, Path};
-use crate::results::{box_once, fold, recurse, then};
+use crate::results::{fold, recurse, then};
 use crate::val::{Val, ValR, ValRs};
 use crate::{rc_lazy_list, Ctx, Error};
 use alloc::{boxed::Box, string::String, vec::Vec};
@@ -115,7 +116,7 @@ pub type UpdatePtr = for<'a> fn(Args<'a>, Cv<'a>, Box<dyn Update<'a> + 'a>) -> V
 impl Native {
     /// Create a native filter from a run function, without support for updates.
     pub const fn new(run: RunPtr) -> Self {
-        Self::with_update(run, |_, _, _| crate::results::box_once(Err(Error::PathExp)))
+        Self::with_update(run, |_, _, _| box_once(Err(Error::PathExp)))
     }
 
     /// Create a native filter from a run function and an update function (used for `filter |= ...`).

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -1,4 +1,4 @@
-use crate::box_iter::{box_once, flat_map_with};
+use crate::box_iter::{box_once, flat_map_with, map_with};
 use crate::path::{self, Path};
 use crate::results::{fold, recurse, then, Results};
 use crate::val::{Val, ValR, ValRs};
@@ -361,7 +361,7 @@ pub trait FilterT<'a>: Clone + 'a {
     /// Run `self` and `r` and return the cartesian product of their outputs.
     fn cartesian(self, r: Self, cv: Cv<'a>) -> Box<dyn Iterator<Item = (ValR, ValR)> + 'a> {
         flat_map_with(self.run(cv.clone()), cv, move |l, cv| {
-            flat_map_with(r.clone().run(cv), l, |r, l| box_once((l, r)))
+            map_with(r.clone().run(cv), l, |r, l| (l, r))
         })
     }
 

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -1,6 +1,6 @@
 use crate::box_iter::box_once;
 use crate::path::{self, Path};
-use crate::results::{fold, recurse, then};
+use crate::results::{fold, recurse, then, Results};
 use crate::val::{Val, ValR, ValRs};
 use crate::{rc_lazy_list, Ctx, Error};
 use alloc::{boxed::Box, string::String, vec::Vec};
@@ -351,7 +351,10 @@ pub trait FilterT<'a>: Clone + 'a {
     ///
     /// This has a special optimisation for the case where only a single `v` is returned.
     /// In that case, we can consume `cv` instead of cloning it.
-    fn pipe(self, cv: Cv<'a>, f: impl Fn(Cv<'a>, Val) -> ValRs<'a> + 'a) -> ValRs<'a> {
+    fn pipe<T: 'a, F>(self, cv: Cv<'a>, f: F) -> Results<'a, T, Error>
+    where
+        F: Fn(Cv<'a>, Val) -> Results<'a, T, Error> + 'a,
+    {
         let mut l = self.run(cv.clone());
 
         // if we expect at most one element from the left side,

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -46,6 +46,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod box_iter;
 pub mod error;
 mod filter;
 mod lazy_iter;

--- a/jaq-interpret/src/results.rs
+++ b/jaq-interpret/src/results.rs
@@ -6,7 +6,7 @@ use crate::box_iter::BoxIter;
 use crate::rc_lazy_list::List;
 use alloc::vec::Vec;
 
-type Results<'a, T, E> = BoxIter<'a, Result<T, E>>;
+pub type Results<'a, T, E> = BoxIter<'a, Result<T, E>>;
 
 /// If `x` is an `Err`, return it as iterator, else apply `f` to `x` and return its output.
 pub fn then<'a, T, U: 'a, E: 'a>(

--- a/jaq-interpret/src/results.rs
+++ b/jaq-interpret/src/results.rs
@@ -1,14 +1,12 @@
 //! Functions on iterators over results.
 
+/// TODO for v2.0: remove this from `results`
+pub use crate::box_iter::box_once;
+use crate::box_iter::BoxIter;
 use crate::rc_lazy_list::List;
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 
-type Results<'a, T, E> = Box<dyn Iterator<Item = Result<T, E>> + 'a>;
-
-/// Return a boxed iterator that yields a single element.
-pub fn box_once<'a, T: 'a>(x: T) -> Box<dyn Iterator<Item = T> + 'a> {
-    Box::new(core::iter::once(x))
-}
+type Results<'a, T, E> = BoxIter<'a, Result<T, E>>;
 
 /// If `x` is an `Err`, return it as iterator, else apply `f` to `x` and return its output.
 pub fn then<'a, T, U: 'a, E: 'a>(

--- a/jaq-interpret/src/results.rs
+++ b/jaq-interpret/src/results.rs
@@ -6,6 +6,7 @@ use crate::box_iter::BoxIter;
 use crate::rc_lazy_list::List;
 use alloc::vec::Vec;
 
+/// A boxed iterator over `Result`s.
 pub type Results<'a, T, E> = BoxIter<'a, Result<T, E>>;
 
 /// If `x` is an `Err`, return it as iterator, else apply `f` to `x` and return its output.


### PR DESCRIPTION
This PR makes the evaluation of cartesian products lazy in both arguments.

Previously, only the left-hand side of binary filters (such as addition) were evaluated lazily. As a consequence,

~~~ jq
limit(3; recurse(.+1) + 0)
~~~

would terminate, but

~~~ jq
limit(3; 0 + recurse(.+1))
~~~

would not. With this PR, both variants terminate.

As a downside, the results of the right-hand side are not cached anymore.
That is, `(0, 1) + expensive_f` will now evaluate `expensive_f` twice, whereas it was only evaluated once before.
However, I suppose that the impact of this is minimal, because few people would use multiple inputs in conjunction with "expensive" functions as arguments to binary operators.