### PR TITLE
New call convention for recursive function

### DIFF
--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -15,6 +15,12 @@ yields!(
     [[0, 1], [1, 2], [2, 3]]
 );
 
+yields!(
+    rec_update,
+    "def upto($x): .[$x], (if $x > 0 then upto($x-1) else empty end); [1, 2, 3, 4] | upto(1) |= .+1",
+    [2, 3, 3, 4]
+);
+
 #[test]
 fn ascii() {
     give(json!("aAaAäの"), "ascii_upcase", json!("AAAAäの"));

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -92,32 +92,15 @@ impl<'a> Ctx<'a> {
         self
     }
 
+    /// Remove the `skip` most recent variable bindings.
+    fn skip_vars(mut self, skip: usize) -> Self {
+        self.vars = self.vars.skip(skip).clone();
+        self
+    }
+
     /// Return remaining input values.
     pub fn inputs(&self) -> &'a Inputs<'a> {
         self.inputs
-    }
-
-    /// Obtain and remove the `save` most recent variable bindings,
-    /// then remove additional `skip` most recent bindings,
-    /// finally add the original `save` bindings.
-    ///
-    /// This seemingly complicated behaviour stems from
-    /// calls to recursive filters with `save` variable arguments.
-    /// To call such a filter, we have to first produce the
-    /// argument values and save them in the context.
-    /// Next, we have to remove `skip` variables that might have been bound
-    /// by the last call to the recursive filter.
-    /// Finally, we add the `save` arguments to the context again,
-    /// so that the recursive filter can start again with the same context length.
-    fn save_skip_vars(mut self, save: usize, skip: usize) -> Self {
-        self.vars = if save == 0 {
-            self.vars.skip(skip).clone()
-        } else {
-            let (saved, rest) = self.vars.pop_many(save);
-            let saved = saved.into_iter().rev().cloned();
-            rest.skip(skip).clone().cons_many(saved)
-        };
-        self
     }
 }
 

--- a/jaq-interpret/src/mir.rs
+++ b/jaq-interpret/src/mir.rs
@@ -55,10 +55,6 @@ pub struct Def {
 }
 
 impl Def {
-    pub fn arity(&self) -> usize {
-        self.args.len()
-    }
-
     /// Return the indices of variable and nonvariable arguments of the definition.
     ///
     /// Example: if we have the arguments $f; g; $h; i, then we obtain

--- a/jaq-interpret/src/rc_list.rs
+++ b/jaq-interpret/src/rc_list.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 #[derive(Clone, Debug)]
 pub enum RcList<T> {
     Nil,
@@ -22,9 +20,11 @@ impl<T> RcList<T> {
         Self::Cons(x, alloc::rc::Rc::new(self))
     }
 
+    /*
     pub fn cons_many(self, iter: impl IntoIterator<Item = T>) -> Self {
         iter.into_iter().fold(self, |acc, x| acc.cons(x))
     }
+    */
 
     pub fn get(&self, mut n: usize) -> Option<&T> {
         let mut ctx = self;
@@ -37,29 +37,6 @@ impl<T> RcList<T> {
             }
         }
         None
-    }
-
-    fn pop(&self) -> Option<(&T, &Self)> {
-        match self {
-            Self::Cons(x, xs) => Some((x, xs)),
-            Self::Nil => None,
-        }
-    }
-
-    pub fn pop_many(&self, n: usize) -> (Vec<&T>, &Self) {
-        let mut out = Vec::with_capacity(n);
-
-        let mut ctx = self;
-        for _ in 0..n {
-            match ctx.pop() {
-                Some((x, xs)) => {
-                    out.push(x);
-                    ctx = xs
-                }
-                None => return (out, &Self::Nil),
-            }
-        }
-        (out, ctx)
     }
 
     pub fn skip(&self, n: usize) -> &Self {
@@ -90,10 +67,6 @@ fn test() {
 
     let l = RcList::new().cons(2).cons(1).cons(0);
     eq(&l, vec![0, 1, 2]);
-
-    let (popped, rest) = l.pop_many(2);
-    assert_eq!(popped, vec![&0, &1]);
-    eq(rest, vec![2]);
 
     eq(l.skip(0), vec![0, 1, 2]);
     eq(l.skip(1), vec![1, 2]);


### PR DESCRIPTION
This PR improves the calling of recursive functions with variable arguments.

Previously, when calling a recursive filter with arguments, say `rec($x1; ...; $xn)` as `rec(f1; ...; fn)`, jaq would bind the output of every `fi` to `$xi`, then pop them from the context, pop some more of the context until reaching the original context in which `rec` should be run, then cons the `$xi` again to the context.

After this change, jaq first pops some elements of the context, and then directly binds the `fi` to `$xi`.
That means that for every recursive function call with `n` arguments, we save `n` list pop and `n` cons operations, as well as an allocation (for remembering each `$xi`).

This paves the way towards recursive functions with non-variable arguments.