### PR TITLE
Make Rc lists clonable without cloning any of its elements.

### DIFF
--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -67,7 +67,7 @@ pub use val::{Val, ValR, ValRs};
 
 use alloc::string::String;
 use lazy_iter::LazyIter;
-use rc_list::RcList;
+use rc_list::List as RcList;
 
 type Inputs<'i> = RcIter<dyn Iterator<Item = Result<Val, String>> + 'i>;
 
@@ -82,7 +82,7 @@ pub struct Ctx<'a> {
 impl<'a> Ctx<'a> {
     /// Construct a context.
     pub fn new(vars: impl IntoIterator<Item = Val>, inputs: &'a Inputs<'a>) -> Self {
-        let vars = vars.into_iter().fold(RcList::Nil, |acc, v| acc.cons(v));
+        let vars = RcList::new().extend(vars);
         Self { vars, inputs }
     }
 


### PR DESCRIPTION
This PR makes reference-counted lists clonable without cloning any of its elements.

Reference-counted lists are used to store the contents of bound variables in jaq.
As they are part of the filter execution context, they are very frequently cloned.
So far, cloning such a list would always clone the head of list, in addition to cloning an `Rc`-pointer to the tail of the list.
After this change, cloning only clones an `Rc`-pointer to the list.

The performance implication of this change is quite favourable:

|Benchmark|n|Before|After|
|---|--:|--:|--:|
|`empty`|512|**630**|650
|`bf-fib`|13|400|**380**
|`reverse`|1048576|**30**|**30**
|`sort`|1048576|**100**|**100**
|`group-by`|1048576|440|**390**
|`min-max`|1048576|**180**|**180**
|`add`|1048576|460|**420**
|`kv`|131072|**140**|150
|`kv-update`|131072|**150**|**150**
|`kv-entries`|131072|590|**560**
|`ex-implode`|1048576|750|**740**
|`reduce`|1048576|720|**690**
|`try-catch`|1048576|150|**130**
|`tree-flatten`|17|450|**420**
|`tree-update`|17|280|**260**
|`tree-paths`|17|1250|**1210**
|`to-fromjson`|65536|**30**|**30**
|`ack`|7|560|**520**