### PR TITLE
First-order recursive filters

### DIFF
--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -7,6 +7,8 @@ use jaq_interpret::error::{Error, Type};
 use jaq_interpret::Val;
 use serde_json::json;
 
+yields!(repeat, "def r(f): f, r(f); [limit(3; r(1, 2))]", [1, 2, 1]);
+
 yields!(nested_rec, "def f: def g: 0, g; g; def h: h; first(f)", 0);
 
 yields!(

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -16,7 +16,7 @@ pub struct Owned(Ast, Vec<Def>);
 pub struct Ref<'a>(&'a Ast, &'a [Def]);
 
 #[derive(Debug, Clone)]
-pub struct Def {
+pub(crate) struct Def {
     pub rhs: Ast,
 }
 
@@ -28,7 +28,7 @@ impl Owned {
 
 /// Function from a value to a stream of value results.
 #[derive(Clone, Debug, Default)]
-pub enum Ast {
+pub(crate) enum Ast {
     #[default]
     Id,
     ToString,
@@ -86,7 +86,7 @@ pub enum Ast {
     Call {
         skip: usize,
         id: usize,
-        args: Vec<Self>,
+        args: Vec<Bind<Self, Self>>,
     },
 
     Native(Native, Vec<Self>),
@@ -104,17 +104,17 @@ dyn_clone::clone_trait_object!(<'a> Update<'a>);
 /// and return the enhanced contexts together with the original value of `cv`.
 ///
 /// This is used when we call filters with variable arguments.
-fn bind_vars<'a, F, I>(mut args: I, ctx: Ctx<'a>, cv: Cv<'a>) -> Results<'a, Cv<'a>, Error>
+fn bind_vars<'a, I>(mut args: I, ctx: Ctx<'a>, cv: Cv<'a>) -> Results<'a, Cv<'a>, Error>
 where
-    F: FilterT<'a>,
-    I: Iterator<Item = F> + Clone + 'a,
+    I: Iterator<Item = Bind<Ref<'a>, Ref<'a>>> + Clone + 'a,
 {
     match args.next() {
-        Some(arg) => flat_map_with(
+        Some(Bind::Var(arg)) => flat_map_with(
             arg.run(cv.clone()),
             (ctx, cv, args),
             |y, (ctx, cv, args)| then(y, |y| bind_vars(args, ctx.cons_var(y), cv)),
         ),
+        Some(Bind::Fun(Ref(arg, _defs))) => bind_vars(args, ctx.cons_fun((arg, cv.0.clone())), cv),
         None => box_once(Ok((ctx, cv.1))),
     }
 }
@@ -283,12 +283,12 @@ impl<'a> FilterT<'a> for Ref<'a> {
 
             Ast::Var(v) => match cv.0.vars.get(*v).unwrap() {
                 Bind::Var(v) => box_once(Ok(v.clone())),
-                Bind::Fun(f) => f.0.run((f.1.clone(), cv.1)),
+                Bind::Fun(f) => w(f.0).run((f.1.clone(), cv.1)),
             },
             Ast::Call { skip, id, args } => Box::new(crate::LazyIter::new(move || {
                 let def = &self.1[*id];
                 let ctx = cv.0.clone().skip_vars(*skip);
-                let ctxs = bind_vars(args.iter().map(w), ctx, cv);
+                let ctxs = bind_vars(args.iter().map(move |a| a.as_deref().map(w)), ctx, cv);
                 ctxs.flat_map(move |cv| then(cv, |cv| w(&def.rhs).run(cv)))
             })),
 
@@ -339,13 +339,14 @@ impl<'a> FilterT<'a> for Ref<'a> {
 
             Ast::Var(v) => match cv.0.vars.get(*v).unwrap() {
                 Bind::Var(_) => err,
-                Bind::Fun(l) => l.0.update((l.1.clone(), cv.1), f),
+                Bind::Fun(l) => w(l.0).update((l.1.clone(), cv.1), f),
             },
             Ast::Call { skip, id, args } => {
                 let def = &self.1[*id];
                 let ctx = cv.0.clone().skip_vars(*skip);
                 let init = box_once(Ok(cv.1.clone()));
-                let ctxs = rc_lazy_list::List::from_iter(bind_vars(args.iter().map(w), ctx, cv));
+                let ctxs = bind_vars(args.iter().map(move |a| a.as_deref().map(w)), ctx, cv);
+                let ctxs = rc_lazy_list::List::from_iter(ctxs);
                 Box::new(fold(false, ctxs, init, move |cv, v| {
                     w(&def.rhs).update((cv.0, v), f.clone())
                 }))

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -92,6 +92,7 @@ impl<'a> Ctx<'a> {
         self
     }
 
+    /// Add a new filter binding.
     pub(crate) fn cons_fun(mut self, f: (&'a filter::Ast, Self)) -> Self {
         self.vars = self.vars.cons(Bind::Fun(f));
         self

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -64,7 +64,7 @@ pub use filter::{Args, FilterT, Native, Owned as Filter, RunPtr, UpdatePtr};
 pub use rc_iter::RcIter;
 pub use val::{Val, ValR, ValRs};
 
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use jaq_syn::Arg as Bind;
 use lazy_iter::LazyIter;
 use rc_list::List as RcList;
@@ -109,12 +109,13 @@ impl<'a> Ctx<'a> {
     }
 }
 
-use alloc::vec::Vec;
-use jaq_syn::Spanned;
+/// Combined MIR/LIR compilation.
+///
+/// This allows to go from a parsed filter to a filter executable by this crate.
 pub struct ParseCtx {
     /// errors occurred during transformation
     // TODO for v2.0: remove this and make it a function
-    pub errs: Vec<Spanned<mir::Error>>,
+    pub errs: Vec<jaq_syn::Spanned<mir::Error>>,
     native: Vec<(String, usize, filter::Native)>,
     def: jaq_syn::Def,
 }

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -66,44 +66,11 @@ pub use rc_iter::RcIter;
 pub use val::{Val, ValR, ValRs};
 
 use alloc::string::String;
+use jaq_syn::Arg as Bind;
 use lazy_iter::LazyIter;
 use rc_list::List as RcList;
 
 type Inputs<'i> = RcIter<dyn Iterator<Item = Result<Val, String>> + 'i>;
-
-/// Binding of a value or a filter.
-///
-/// In jq, we can bind filters in three different ways:
-///
-/// 1. `f as $x | ...`
-/// 2. `def g($x): ...; g(f)`
-/// 3. `def g(fx): ...; g(f)`
-///
-/// In the first two cases, we bind the outputs of `f` to a variable `$x`.
-/// In the third case, we bind `f` to a filter `fx`
-#[derive(Debug, Clone)]
-pub(crate) enum Bind<V, F> {
-    Var(V),
-    Fun(F),
-}
-
-impl<T> Bind<T, T> {
-    fn map<U>(self, f: impl FnOnce(T) -> U) -> Bind<U, U> {
-        match self {
-            Self::Var(x) => Bind::Var(f(x)),
-            Self::Fun(x) => Bind::Fun(f(x)),
-        }
-    }
-}
-
-impl<V, F> Bind<V, F> {
-    fn as_deref(&self) -> Bind<&V, &F> {
-        match self {
-            Self::Var(x) => Bind::Var(x),
-            Self::Fun(x) => Bind::Fun(x),
-        }
-    }
-}
 
 /// Filter execution context.
 #[derive(Clone)]

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -54,7 +54,6 @@ impl Ctx {
     fn def(&mut self, def: mir::Def) {
         let id = AbsId(self.defs.len());
         self.defs.push(Def {
-            // TODO: set rec!
             rec: false,
             rhs: Filter::default(),
         });

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -1,152 +1,77 @@
 //! Low-level Intermediate Representation of filters.
-//!
-//! Welcome to the machine room. Be careful to wear safety equipment.
-//! The invariants in this module can be difficult to preserve.
-//! `assert!` your way around here and watch your step.
 
-use crate::filter::{self, Ast as Filter};
-use crate::mir::{self, DefId, MirFilter};
+use crate::filter::{self, Ast as Filter, Def};
+use crate::mir::{self, MirFilter, RelId, Relative};
 use crate::path::{self, Path};
-use crate::Bind;
 use alloc::{boxed::Box, vec::Vec};
 use jaq_syn::filter::{AssignOp, BinaryOp, Fold, KeyVal};
 use jaq_syn::{MathOp, Str};
 
-#[derive(Debug, Clone, Default)]
-struct View {
-    /// indices of variables in the execution context that are currently visible
-    vars: Vec<usize>,
-    args: Vec<usize>,
-    recs: Vec<usize>,
-}
-
-impl View {
-    fn find_rec(&self, id: DefId, recs: &[Rec]) -> Option<usize> {
-        self.recs.iter().find(|ridx| recs[**ridx].id == id).copied()
-    }
-
-    /// Keep only the variables and arguments bound in the given definition.
-    fn truncate(&mut self, id: DefId, defs: &mir::Defs) {
-        let (vars, args): (Vec<_>, Vec<_>) = defs.args(id).partition(|a| a.is_var());
-        assert!(vars.len() <= self.vars.len());
-        assert!(args.len() <= self.args.len());
-        self.vars.truncate(vars.len());
-        self.args.truncate(args.len());
-    }
-}
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct AbsId(usize);
 
 #[derive(Default)]
-struct Ctx {
-    /// number of variables in the execution context at the current point
-    vars: usize,
-    /// non-variable arguments, earliest bound first
-    args: Vec<(MirFilter, DefId, View)>,
-    /// list of recursively defined filters with their arity (only variable arguments)
-    /// and the number of bound variables (including variable arguments)
-    /// that must be in the context at the time of calling
-    recs: Vec<Rec>,
+pub struct Ctx {
+    defs: Vec<Def>,
+    callable: Vec<Callable>,
 }
 
-pub struct Rec {
-    id: DefId,
-    vars_len: usize,
-    filter: Filter,
+pub struct Callable {
+    typ: Relative,
+    sig: jaq_syn::Call,
+    id: AbsId,
 }
 
-pub fn root_def(defs: &mir::Defs) -> filter::Owned {
-    //std::dbg!(defs);
-    let root_id = 0;
-    //let vars = defs.get(root_id).args.len();
+pub fn root_def(def: mir::Def) -> filter::Owned {
     let mut ctx = Ctx::default();
-    let view = View::default();
-    let f = ctx.def(root_id, view, defs);
-    let recs = ctx.recs.into_iter();
-    let recs = recs.map(|rec| {
-        filter::Def {
-            rec: true,
-            rhs: rec.filter,
-        }
-    });
-    filter::Owned::new(f, recs.collect())
+    ctx.def(def);
+    filter::Owned::new(ctx.defs[0].rhs.clone(), ctx.defs)
 }
 
-// this has to be fulfilled for the IDs of the filters in any `view.recs`
-fn sorted_and_unique<T: Ord + core::hash::Hash + Clone>(iter: impl Iterator<Item = T>) -> bool {
-    use itertools::Itertools;
-    let v: Vec<_> = iter.collect();
-    let mut sorted = v.clone();
-    sorted.sort();
-    v.iter().all_unique() && v == sorted
-}
+// TODO: remove itertools dependency
 
 impl Ctx {
-    fn def(&mut self, id: DefId, mut view: View, defs: &mir::Defs) -> Filter {
-        let def = defs.get(id);
-        //std::dbg!("processing def", (&def.name, id, &view));
-
-        let var_args = def.args.iter().filter(|a| a.is_var()).count();
-        view.vars.extend(self.vars..self.vars + var_args);
-        self.vars += var_args;
-
-        let view_vars_len = view.vars.len();
-        for rec_id in def.children.iter().filter(|cid| defs.get(**cid).recursive) {
-            //std::dbg!("processing recursive child", rec_id);
-            let rec = defs.get(*rec_id);
-            assert!(rec.args.iter().all(|a| a.is_var()));
-            let new_rec_idx = self.recs.len();
-            view.recs.push(new_rec_idx);
-            // put in a bogus filter that we replace later
-            self.recs.push(Rec {
-                id: *rec_id,
-                vars_len: self.vars,
-                filter: Filter::Id,
-            });
-            // std::dbg!(&self.recs);
-            let f = self.def(*rec_id, view.clone(), defs);
-            self.recs[new_rec_idx].filter = f;
-        }
-        assert_eq!(view.vars.len(), view_vars_len);
-
-        //std::dbg!("rec defs done for", id, &view);
-        //std::dbg!("now for the body of the definition", &def.body);
-
-        let out = self.filter(def.body.clone(), id, view, defs);
-        self.vars -= var_args;
-        out
+    fn get_callable(&self, RelId(id): RelId) -> &Callable {
+        &self.callable[id]
     }
 
-    fn nonrec_call(
-        &mut self,
-        caller: DefId,
-        callee: DefId,
-        view: &View,
-        nonvar_args: impl Iterator<Item = MirFilter>,
-        defs: &mir::Defs,
-    ) -> Filter {
-        let last_common = defs.smallest_common_ancestor(caller, callee);
-        let mut new_view = view.clone();
-        new_view.truncate(last_common, defs);
-        // we ban all recursive filters from the view that come "after"
-        // the filter that we are calling
-        // this relies on the property that filter IDs preserve order of definition
-        new_view.recs.retain(|ridx| self.recs[*ridx].id < callee);
-        //std::dbg!(&view, &new_view);
-
-        for arg in nonvar_args {
-            new_view.args.push(self.args.len());
-            self.args.push((arg, caller, view.clone()));
-        }
-
-        self.def(callee, new_view, defs)
+    fn get_def(&mut self, AbsId(id): AbsId) -> &mut Def {
+        &mut self.defs[id]
     }
 
-    /// Convert a MIR filter contained in a definition `id` to a LIR filter.
-    // TODO: operate on borrowed filter
-    // the problem here is that for calls to arguments,
-    // we need to access self.args, but we cannot pass the filter contained to it
-    // to this function, because it mutably borrows self
-    fn filter(&mut self, f: MirFilter, id: DefId, mut view: View, defs: &mir::Defs) -> Filter {
-        let get = |f, ctx: &mut Self| Box::new(ctx.filter(f, id, view.clone(), defs));
+    fn main(&mut self, main: mir::Main) -> Filter {
+        let defs_len = main.defs.len();
+        main.defs.into_iter().for_each(|def| self.def(def));
+        let body = self.filter(main.body);
+
+        self.callable
+            .drain(self.callable.len() - defs_len..)
+            .for_each(|callable| assert_eq!(callable.typ, Relative::Sibling));
+
+        body
+    }
+
+    fn def(&mut self, def: mir::Def) {
+        let id = AbsId(self.defs.len());
+        self.defs.push(Def {
+            // TODO: set rec!
+            rec: false,
+            rhs: Filter::default(),
+        });
+        self.callable.push(Callable {
+            typ: Relative::Parent,
+            sig: def.lhs.clone(),
+            id,
+        });
+        self.get_def(id).rhs = self.main(def.rhs);
+        let last = self.callable.last_mut().unwrap();
+        assert!(last.id == id);
+        last.typ = Relative::Sibling;
+    }
+
+    /// Convert a MIR filter to a LIR filter.
+    fn filter(&mut self, f: MirFilter) -> Filter {
+        let get = |f, ctx: &mut Self| Box::new(ctx.filter(f));
         let of_str = |s: Str<_>, ctx: &mut Self| {
             let fmt = s.fmt.map_or(Filter::ToString, |fmt| *get(*fmt, ctx));
             use jaq_syn::string::Part;
@@ -161,104 +86,30 @@ impl Ctx {
         };
         use mir::Filter as Expr;
 
-        //std::dbg!(self.vars);
-        //std::dbg!(&view.vars);
-        //std::dbg!(&f.0);
         match f.0 {
-            Expr::Var(v) => Filter::Var(self.vars - view.vars[v] - 1),
-            Expr::Call(mir::Call::Native(n), args) => {
-                let args = args.into_iter().map(|a| *get(a, self));
-                Filter::Native(n, args.collect())
-            }
-            Expr::Call(mir::Call::Arg(a), args) => {
-                //std::dbg!("arg call");
-                assert!(args.is_empty());
-                assert!(sorted_and_unique(view.args.iter()));
-                // all accessible arguments are in the context
-                assert!(view.args.iter().all(|aidx| *aidx < self.args.len()));
-                // only actual arguments are accessible
-                assert_eq!(
-                    view.args.len(),
-                    defs.args(id).filter(|a| !a.is_var()).count()
-                );
-                let (f, id, view) = self.args[view.args[a]].clone();
-                self.filter(f, id, view, defs)
-            }
-            Expr::Call(mir::Call::Def(did), args) => {
-                let args_len = self.args.len();
-                let (var_arg_idxs, nonvar_arg_idxs) = defs.get(did).var_nonvar_arg_idxs();
-                let var_args = var_arg_idxs.iter().map(|i| args[*i].clone());
-                let nonvar_args = nonvar_arg_idxs.iter().map(|i| args[*i].clone());
-
-                //std::dbg!(id);
-
-                assert!(sorted_and_unique(
-                    view.recs.iter().map(|ridx| self.recs[*ridx].id)
-                ));
-                // recursion!
-                let filter = if let Some(rec_idx) = view.find_rec(did, &self.recs) {
-                    let var_args = var_args
-                        .map(|a| Bind::Var(self.filter(a, id, view.clone(), defs)))
-                        .collect();
-                    //std::dbg!("call a recursive filter!", did);
-                    //  std::dbg!(&self.recs);
-                    //  std::dbg!(&view.recs);
-                    // arguments bound in the called filter and its ancestors
-                    let vars_len = self.recs[rec_idx].vars_len;
-                    //std::dbg!(var_args.len(), self.vars, vars_len);
-                    Filter::Call {
-                        id: rec_idx,
-                        skip: self.vars - vars_len,
-                        args: var_args,
+            Expr::Var(v) => Filter::Var(v),
+            Expr::Call(call, args) => {
+                let args: Vec<_> = args.into_iter().map(|a| *get(a, self)).collect();
+                match call {
+                    mir::Call::Arg(a) if args.is_empty() => Filter::Var(a),
+                    mir::Call::Arg(_) => panic!("higher-order argument encountered"),
+                    mir::Call::Native(n) => Filter::Native(n, args),
+                    mir::Call::Def { id, skip } => {
+                        let callable = self.get_callable(id);
+                        let args = callable.sig.args.iter().zip(args);
+                        let args = args.map(|(ty, a)| ty.as_ref().map(|_| a)).collect();
+                        let id = callable.id;
+                        if callable.typ == Relative::Parent {
+                            self.get_def(id).rec = true;
+                        }
+                        let AbsId(id) = id;
+                        Filter::Call { skip, args, id }
                     }
-                } else {
-                    let var_args: Vec<_> = var_args
-                        .map(|a| {
-                            //std::dbg!(&view, self.vars);
-                            let arg = self.filter(a, id, view.clone(), defs);
-                            self.vars += 1;
-                            // TODO: increase view.vars? probably not ...
-                            arg
-                        })
-                        .collect();
-                    self.vars -= var_args.len();
-
-                    // here, we revert the order, because leftmost variable arguments are bound first, which means
-                    // they will appear *outermost* in the filter, thus have to be added *last* to the filter
-                    let out = self.nonrec_call(id, did, &view, nonvar_args, defs);
-                    var_args.into_iter().rev().fold(out, |acc, arg| {
-                        Filter::Pipe(Box::new(arg), true, Box::new(acc))
-                    })
-                };
-
-                // std::dbg!("return from filter construction");
-                self.args.truncate(self.args.len() - nonvar_arg_idxs.len());
-                // we must be back to the original args len here
-                assert_eq!(self.args.len(), args_len);
-
-                filter
+                }
             }
 
-            // variable-binding operators
-            Expr::Binary(l, BinaryOp::Pipe(Some(_x)), r) => {
-                let l = get(*l, self);
-
-                view.vars.push(self.vars);
-                self.vars += 1;
-                let r = Box::new(self.filter(*r, id, view, defs));
-                self.vars -= 1;
-
-                Filter::Pipe(l, true, r)
-            }
             Expr::Fold(typ, Fold { xs, init, f, .. }) => {
-                let (xs, init) = (get(*xs, self), get(*init, self));
-
-                view.vars.push(self.vars);
-                self.vars += 1;
-                let f = Box::new(self.filter(*f, id, view, defs));
-                self.vars -= 1;
-
-                Filter::Fold(typ, xs, init, f)
+                Filter::Fold(typ, get(*xs, self), get(*init, self), get(*f, self))
             }
 
             Expr::Id => Filter::Id,
@@ -289,25 +140,22 @@ impl Ctx {
             Expr::Neg(f) => Filter::Neg(get(*f, self)),
             Expr::Recurse => Filter::recurse0(),
 
-            Expr::Binary(l, BinaryOp::Pipe(None), r) => {
-                Filter::Pipe(get(*l, self), false, get(*r, self))
-            }
-            Expr::Binary(l, BinaryOp::Comma, r) => Filter::Comma(get(*l, self), get(*r, self)),
-            Expr::Binary(l, BinaryOp::Alt, r) => Filter::Alt(get(*l, self), get(*r, self)),
-            Expr::Binary(l, BinaryOp::Or, r) => Filter::Logic(get(*l, self), true, get(*r, self)),
-            Expr::Binary(l, BinaryOp::And, r) => Filter::Logic(get(*l, self), false, get(*r, self)),
-            Expr::Binary(l, BinaryOp::Math(op), r) => {
-                Filter::Math(get(*l, self), op, get(*r, self))
-            }
-            Expr::Binary(l, BinaryOp::Ord(op), r) => Filter::Ord(get(*l, self), op, get(*r, self)),
-            Expr::Binary(l, BinaryOp::Assign(op), r) => {
+            Expr::Binary(l, op, r) => {
                 let (l, r) = (get(*l, self), get(*r, self));
                 match op {
-                    AssignOp::Assign => Filter::Assign(l, r),
-                    AssignOp::Update => Filter::Update(l, r),
-                    AssignOp::UpdateWith(op) => Filter::UpdateMath(l, op, r),
+                    BinaryOp::Pipe(bind) => Filter::Pipe(l, bind.is_some(), r),
+                    BinaryOp::Comma => Filter::Comma(l, r),
+                    BinaryOp::Alt => Filter::Alt(l, r),
+                    BinaryOp::Or => Filter::Logic(l, true, r),
+                    BinaryOp::And => Filter::Logic(l, false, r),
+                    BinaryOp::Math(op) => Filter::Math(l, op, r),
+                    BinaryOp::Ord(op) => Filter::Ord(l, op, r),
+                    BinaryOp::Assign(AssignOp::Assign) => Filter::Assign(l, r),
+                    BinaryOp::Assign(AssignOp::Update) => Filter::Update(l, r),
+                    BinaryOp::Assign(AssignOp::UpdateWith(op)) => Filter::UpdateMath(l, op, r),
                 }
             }
+
             Expr::Ite(if_thens, else_) => {
                 let else_ = else_.map_or(Filter::Id, |else_| *get(*else_, self));
                 if_thens.into_iter().rev().fold(else_, |acc, (if_, then_)| {

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -7,6 +7,7 @@
 use crate::filter::{self, Ast as Filter};
 use crate::mir::{self, DefId, MirFilter};
 use crate::path::{self, Path};
+use crate::Bind;
 use alloc::{boxed::Box, vec::Vec};
 use jaq_syn::filter::{AssignOp, BinaryOp, Fold, KeyVal};
 use jaq_syn::{MathOp, Str};
@@ -192,7 +193,7 @@ impl Ctx {
                 // recursion!
                 let filter = if let Some(rec_idx) = view.find_rec(did, &self.recs) {
                     let var_args = var_args
-                        .map(|a| self.filter(a, id, view.clone(), defs))
+                        .map(|a| Bind::Var(self.filter(a, id, view.clone(), defs)))
                         .collect();
                     //std::dbg!("call a recursive filter!", did);
                     //  std::dbg!(&self.recs);

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -61,7 +61,12 @@ pub fn root_def(defs: &mir::Defs) -> filter::Owned {
     let view = View::default();
     let f = ctx.def(root_id, view, defs);
     let recs = ctx.recs.into_iter();
-    let recs = recs.map(|rec| (filter::Def { rhs: rec.filter }));
+    let recs = recs.map(|rec| {
+        filter::Def {
+            rec: true,
+            rhs: rec.filter,
+        }
+    });
     filter::Owned::new(f, recs.collect())
 }
 

--- a/jaq-interpret/src/mir.rs
+++ b/jaq-interpret/src/mir.rs
@@ -4,23 +4,27 @@
 //! but replaces names by unique integers.
 //! That way, the subsequent transformation step(s)
 //! always succeed and do not have to fight with shadowing.
-//! But most importantly, this allows us to record recursive calls.
 
+use crate::Bind;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 use jaq_syn::filter::{BinaryOp, Filter as Expr, Fold};
 use jaq_syn::{Arg, Spanned};
 
-type HirFilter = Spanned<jaq_syn::filter::Filter>;
+// TODO: remove MirFilter
 pub type MirFilter = Spanned<Filter>;
+pub type Filter = jaq_syn::filter::Filter<Call, VarIdx, Num>;
+pub type Main = jaq_syn::Main<Filter>;
+pub type Def = jaq_syn::Def<Main>;
 
-pub type DefId = usize;
+#[derive(Debug, Clone)]
+pub struct RelId(pub usize);
 type VarIdx = usize;
 type ArgIdx = usize;
 
 #[derive(Debug, Clone)]
 pub enum Call {
-    Def(DefId),
+    Def { id: RelId, skip: usize },
     Arg(ArgIdx),
     Native(crate::filter::Native),
 }
@@ -41,113 +45,7 @@ impl Num {
     }
 }
 
-pub type Filter = jaq_syn::filter::Filter<Call, VarIdx, Num>;
-
-#[derive(Debug)]
-pub struct Def {
-    // TODO: convert name and args to Call
-    pub name: String,
-    pub args: Vec<Arg>,
-    pub children: Vec<DefId>,
-    ancestors: Vec<DefId>,
-    pub recursive: bool,
-    pub body: Spanned<Filter>,
-}
-
-impl Def {
-    /// Return the indices of variable and nonvariable arguments of the definition.
-    ///
-    /// Example: if we have the arguments $f; g; $h; i, then we obtain
-    /// the variable indices [0, 2] and
-    /// the nonvariable indices [1, 3].
-    ///
-    /// Does not consider ancestors.
-    pub fn var_nonvar_arg_idxs(&self) -> (Vec<usize>, Vec<usize>) {
-        (0..self.args.len()).partition(|i| self.args[*i].is_var())
-    }
-}
-
-/// Link names and arities to corresponding filters.
-///
-/// For example, if we define a filter `def map(f): [.[] | f]`,
-/// then the definitions will associate `map/1` to its definition.
-pub struct Defs(Vec<Def>);
-
-impl Defs {
-    /// Create new definitions that have access to global variables of the given names.
-    pub fn new(vars: Vec<String>) -> Self {
-        use alloc::string::ToString;
-        let root = Def {
-            name: "".to_string(),
-            args: vars.into_iter().map(Arg::new_var).collect(),
-            children: Vec::new(),
-            ancestors: Vec::new(),
-            recursive: false,
-            body: (Filter::Id, 0..0),
-        };
-        Self(Vec::from([root]))
-    }
-
-    pub fn get(&self, id: DefId) -> &Def {
-        &self.0[id]
-    }
-
-    pub fn smallest_common_ancestor(&self, id1: DefId, id2: DefId) -> DefId {
-        let mut a1 = self.ancestors_and_me(id1);
-        let mut a2 = self.ancestors_and_me(id2);
-        let mut last = 0;
-        while let (Some(a1), Some(a2)) = (a1.next(), a2.next()) {
-            if a1 == a2 {
-                last = a1
-            } else {
-                break;
-            }
-        }
-        last
-    }
-
-    /// Return the IDs of the ancestors of a definition and itself.
-    fn ancestors_and_me(&self, id: DefId) -> impl Iterator<Item = DefId> + '_ {
-        use core::iter::once;
-        self.0[id].ancestors.iter().copied().chain(once(id))
-    }
-
-    /// Return all arguments bound in a definition and its ancestors.
-    pub fn args(&self, id: DefId) -> impl Iterator<Item = &Arg> + '_ {
-        self.ancestors_and_me(id)
-            .flat_map(|aid| self.0[aid].args.iter())
-    }
-
-    /// Retrieve the position of an argument of a filter, relative to all its ancestors.
-    ///
-    /// This does not try to find arguments of ancestors,
-    /// but it will offset the index of the argument by the ancestor arguments.
-    fn nonvar_arg_position(&self, id: DefId, name: &str) -> Option<usize> {
-        let args = self.0[id].args.iter();
-        let filter_args: Vec<_> = args.filter_map(|a| a.get_filter()).collect();
-        let i = filter_args.into_iter().rposition(|arg| arg == name)?;
-        let ancestors = self.0[id].ancestors.iter();
-        let ancestor_args = ancestors.flat_map(|aid| self.0[*aid].args.iter());
-        Some(i + ancestor_args.filter(|a| !a.is_var()).count())
-    }
-}
-
-const ROOT_ID: usize = 0;
-
-/// HIR to MIR transformation.
-pub struct Ctx {
-    /// errors occurred during transformation
-    pub errs: Vec<Spanned<Error>>,
-    /// IDs of recursive definitions
-    recs: Vec<DefId>,
-    /// accessible defined filters
-    pub(crate) defs: Defs,
-    /// accessible native filters
-    native: Vec<(String, usize, crate::filter::Native)>,
-}
-
 pub enum Error {
-    RecCallWithFilterArg,
     Undefined(Arg),
     Num(Num),
 }
@@ -155,9 +53,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::RecCallWithFilterArg => "recursive call of a filter with filter argument",
-            Self::Undefined(a) if a.is_var() => "undefined variable",
-            Self::Undefined(_) => "undefined filter",
+            Self::Undefined(Bind::Var(_)) => "undefined variable",
+            Self::Undefined(Bind::Fun(_)) => "undefined filter",
             Self::Num(Num::Float(_)) => "cannot interpret as floating-point number",
             Self::Num(Num::Int(_)) => "cannot interpret as machine-size integer",
         }
@@ -165,193 +62,151 @@ impl fmt::Display for Error {
     }
 }
 
+struct Callable {
+    typ: Relative,
+    sig: jaq_syn::Call,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Relative {
+    Parent,
+    Sibling,
+}
+
+/// Convert variables to indices.
+#[derive(Default)]
+pub struct Ctx {
+    pub errs: Vec<Spanned<Error>>,
+    /// accessible defined filters
+    callable: Vec<Callable>,
+    /// accessible native filters
+    pub native: Vec<(String, usize, crate::filter::Native)>,
+    /// locally bound variables (not bound by filter definition)
+    vars: Vec<String>,
+}
+
 impl Ctx {
-    /// Initialise new context with list of global variables.
-    ///
-    /// When running a filter produced by this context,
-    /// values corresponding to the variables have to be supplied in the execution context.
-    pub fn new(vars: Vec<String>) -> Self {
-        Self {
-            errs: Vec::new(),
-            recs: Vec::new(),
-            native: Vec::new(),
-            defs: Defs::new(vars),
-        }
-    }
-
-    /// Add a native filter with given name and arity.
-    pub fn insert_native(&mut self, name: String, arity: usize, f: crate::filter::Native) {
-        self.native.push((name, arity, f))
-    }
-
-    /// Add native filters with given names and arities.
-    pub fn insert_natives(
-        &mut self,
-        natives: impl IntoIterator<Item = (String, usize, crate::filter::Native)>,
-    ) {
-        natives
-            .into_iter()
-            .for_each(|(name, arity, f)| self.insert_native(name, arity, f))
-    }
-
-    /// Import parsed definitions, such as obtained from the standard library.
-    ///
-    /// Errors that might occur include undefined variables, for example.
-    pub fn insert_defs(&mut self, defs: impl IntoIterator<Item = jaq_syn::Def>) {
-        defs.into_iter().for_each(|def| self.root_def(def));
-    }
-
-    /// Insert a root definition.
-    pub fn root_def(&mut self, def: jaq_syn::Def) {
-        self.def(Vec::from([ROOT_ID]), def);
-        for rec_idx in &self.recs {
-            self.defs.0[*rec_idx].recursive = true;
-        }
-    }
-
-    /// Insert a root filter.
-    pub fn root_filter(&mut self, filter: HirFilter) {
-        self.defs.0[ROOT_ID].body = self.filter(ROOT_ID, Vec::new(), filter);
-    }
-
-    fn def(&mut self, mut ancestors: Vec<DefId>, def: jaq_syn::Def) {
-        // generate a fresh definition ID
-        let id: DefId = self.defs.0.len();
-        self.defs.0.push(Def {
-            name: def.lhs.name,
-            args: def.lhs.args,
-            children: Vec::new(),
-            ancestors: ancestors.clone(),
-            // after MIR creation, we have to set all filters i with ctx.recursive[i] to defs[i].recursive
-            recursive: false,
-            // for recursion, we want to be able to refer to the filter even before we know
-            // what is its body, which is why we insert a bogus body for now
-            // that we replace later by the real body
-            body: (Filter::Id, 0..0),
+    /// Return all currently bound variables / arguments outside-in.
+    fn bound(&self) -> impl DoubleEndedIterator<Item = Bind<&String, &String>> {
+        let by_def = self.callable.iter().filter_map(|Callable { typ, sig }| {
+            (*typ == Relative::Parent).then_some(sig.args.iter().map(|a| a.as_ref()))
         });
-        if let Some(parent) = ancestors.last() {
-            self.defs.0[*parent].children.push(id);
-        }
-
-        ancestors.push(id);
-
-        for d in def.rhs.defs {
-            self.def(ancestors.clone(), d);
-        }
-
-        self.defs.0[id].body = self.filter(id, Vec::new(), def.rhs.body);
+        by_def.flatten().chain(self.vars.iter().map(Bind::Var))
     }
 
-    fn filter(&mut self, id: DefId, mut vars: Vec<String>, f: HirFilter) -> MirFilter {
-        let with_vars = |f, vars, ctx: &mut Self| Box::new(ctx.filter(id, vars, f));
-        let get = |f, ctx: &mut Self| with_vars(f, vars.clone(), ctx);
+    fn resolve_call(&self, name: &str, arity: usize) -> Option<Call> {
+        let mut bound = self.vars.len();
 
-        let result = match f.0 {
-            Expr::Call(name, args) => {
-                //std::dbg!(&name, &args);
-                let args: Vec<_> = args.into_iter().map(|arg| *get(arg, self)).collect();
-
-                let ancestors: Vec<_> = self.defs.ancestors_and_me(id).collect();
-                //std::dbg!(id, &ancestors);
-                for ancestor in &ancestors {
-                    //std::dbg!("check ancestor", ancestor);
-                    // we can call all previous children of ancestors
-                    // we `rev()` here because later definitions shadow earlier ones
-                    for child_idx in self.defs.0[*ancestor].children.iter().rev() {
-                        let child = &self.defs.0[*child_idx];
-                        if child.name != name || child.args.len() != args.len() {
-                            continue;
-                        }
-
-                        //std::dbg!(child_idx);
-                        // recursion
-                        if ancestors.iter().any(|aid| aid == child_idx) {
-                            //std::dbg!("recursion!");
-                            //std::dbg!(&child.args);
-                            if child.args.iter().any(|a| !a.is_var()) {
-                                self.errs.push((Error::RecCallWithFilterArg, f.1.clone()));
-                            }
-
-                            self.recs.push(*child_idx);
-                        }
-
-                        return (Filter::Call(Call::Def(*child_idx), args), f.1);
+        for (id, Callable { typ, sig }) in self.callable.iter().enumerate().rev() {
+            let id = RelId(id);
+            if *typ == Relative::Parent {
+                for arg in sig.args.iter().rev() {
+                    if arity == 0 && arg.as_deref() == Bind::Fun(name) {
+                        return Some(Call::Arg(bound));
                     }
-
-                    // we cannot call arguments with arguments (no higher-order!)
-                    if !args.is_empty() {
-                        continue;
-                    }
-
-                    // calls to nonvariable arguments
-                    if let Some(i) = self.defs.nonvar_arg_position(*ancestor, &name) {
-                        return (Filter::Call(Call::Arg(i), args), f.1);
-                    }
-                }
-
-                let mut natives = self.native.iter();
-                if let Some((_, _, native)) =
-                    natives.find(|(name_, arity, _)| *name_ == name && *arity == args.len())
-                {
-                    Filter::Call(Call::Native(native.clone()), args)
-                } else {
-                    self.errs
-                        .push((Error::Undefined(Arg::new_filter(name)), f.1.clone()));
-                    Filter::Id
+                    bound += 1;
                 }
             }
+            if name == sig.name && arity == sig.args.len() {
+                return Some(Call::Def { id, skip: bound });
+            }
+        }
+
+        self.native
+            .iter()
+            .find(|(name_, arity_, _)| *name_ == name && *arity_ == arity)
+            .map(|(_, _, native)| Call::Native(native.clone()))
+    }
+
+    pub fn main(&mut self, main: jaq_syn::Main) -> Main {
+        let defs: Vec<_> = main.defs.into_iter().map(|def| self.def(def)).collect();
+        assert!(self.vars.is_empty());
+        let body = self.expr(main.body);
+        assert!(self.vars.is_empty());
+
+        self.callable
+            .drain(self.callable.len() - defs.len()..)
+            .for_each(|callable| assert_eq!(callable.typ, Relative::Sibling));
+
+        jaq_syn::Main { defs, body }
+    }
+
+    pub fn def(&mut self, def: jaq_syn::Def) -> Def {
+        self.callable.push(Callable {
+            typ: Relative::Parent,
+            sig: def.lhs.clone(),
+        });
+        let rhs = self.main(def.rhs);
+        self.callable.last_mut().unwrap().typ = Relative::Sibling;
+        jaq_syn::Def { lhs: def.lhs, rhs }
+    }
+
+    fn expr(&mut self, f: Spanned<Expr>) -> Spanned<Filter> {
+        let get = |ctx: &mut Self, f| Box::new(ctx.expr(f));
+        let undefined = |arg| (Error::Undefined(arg), f.1.clone());
+        let result = match f.0 {
+            Expr::Call(name, args) => {
+                let args: Vec<_> = args.into_iter().map(|arg| self.expr(arg)).collect();
+
+                self.resolve_call(&name, args.len()).map_or_else(
+                    || {
+                        self.errs.push(undefined(Arg::new_filter(name)));
+                        Expr::Id
+                    },
+                    |call| Expr::Call(call, args),
+                )
+            }
             Expr::Var(v) => {
-                let local_vars = vars.iter().map(|v| &**v);
-                let arg_vars = self.defs.args(id).filter_map(|a| a.get_var());
-                let vars: Vec<_> = arg_vars.chain(local_vars).collect();
-                Filter::Var(vars.iter().rposition(|i| *i == v).unwrap_or_else(|| {
-                    self.errs
-                        .push((Error::Undefined(Arg::new_var(v)), f.1.clone()));
+                let idx = self.bound().rev().position(|i| i == Bind::Var(&v));
+                Expr::Var(idx.unwrap_or_else(|| {
+                    self.errs.push(undefined(Arg::Var(v)));
                     0
                 }))
             }
             Expr::Binary(l, BinaryOp::Pipe(Some(x)), r) => {
-                let l = get(*l, self);
-                vars.push(x.clone());
-                let r = with_vars(*r, vars, self);
-                Filter::Binary(l, BinaryOp::Pipe(Some(x)), r)
+                let l = get(self, *l);
+                self.vars.push(x.clone());
+                let r = get(self, *r);
+                assert!(self.vars.pop().as_ref() == Some(&x));
+                Expr::Binary(l, BinaryOp::Pipe(Some(x)), r)
             }
             Expr::Fold(typ, Fold { xs, x, init, f }) => {
-                let (xs, init) = (get(*xs, self), get(*init, self));
-                vars.push(x.clone());
-                let f = with_vars(*f, vars, self);
-                Filter::Fold(typ, Fold { xs, x, init, f })
+                let (xs, init) = (get(self, *xs), get(self, *init));
+                self.vars.push(x.clone());
+                let f = get(self, *f);
+                assert!(self.vars.pop().as_ref() == Some(&x));
+                Expr::Fold(typ, Fold { xs, x, init, f })
             }
-            Expr::Id => Filter::Id,
-            Expr::Num(n) => Filter::Num(Num::parse(&n).unwrap_or_else(|n| {
+            Expr::Id => Expr::Id,
+            Expr::Num(n) => Expr::Num(Num::parse(&n).unwrap_or_else(|n| {
                 self.errs.push((Error::Num(n), f.1.clone()));
                 n
             })),
-            Expr::Str(s) => Filter::Str(Box::new((*s).map(|f| *get(f, self)))),
-            Expr::Array(a) => Filter::Array(a.map(|a| get(*a, self))),
+            Expr::Str(s) => Expr::Str(Box::new((*s).map(|f| self.expr(f)))),
+            Expr::Array(a) => Expr::Array(a.map(|a| get(self, *a))),
             Expr::Object(o) => {
-                Filter::Object(o.into_iter().map(|kv| kv.map(|f| *get(f, self))).collect())
+                Expr::Object(o.into_iter().map(|kv| kv.map(|f| self.expr(f))).collect())
             }
-            Expr::Try(f) => Filter::Try(get(*f, self)),
-            Expr::Neg(f) => Filter::Neg(get(*f, self)),
-            Expr::Recurse => Filter::Recurse,
+            Expr::Try(f) => Expr::Try(get(self, *f)),
+            Expr::Neg(f) => Expr::Neg(get(self, *f)),
+            Expr::Recurse => Expr::Recurse,
 
-            Expr::Binary(l, op, r) => Filter::Binary(get(*l, self), op, get(*r, self)),
+            Expr::Binary(l, op, r) => Expr::Binary(get(self, *l), op, get(self, *r)),
             Expr::Ite(if_thens, else_) => {
                 let if_thens = if_thens
                     .into_iter()
-                    .map(|(i, t)| (*get(i, self), *get(t, self)));
-                Filter::Ite(if_thens.collect(), else_.map(|else_| get(*else_, self)))
+                    .map(|(i, t)| (self.expr(i), self.expr(t)));
+                Expr::Ite(if_thens.collect(), else_.map(|else_| get(self, *else_)))
             }
             Expr::TryCatch(try_, catch_) => {
-                Filter::TryCatch(get(*try_, self), catch_.map(|c| get(*c, self)))
+                Expr::TryCatch(get(self, *try_), catch_.map(|c| get(self, *c)))
             }
             Expr::Path(f, path) => {
-                let f = get(*f, self);
+                let f = get(self, *f);
                 let path = path
                     .into_iter()
-                    .map(|(p, opt)| (p.map(|p| *get(p, self)), opt));
-                Filter::Path(f, path.collect())
+                    .map(|(p, opt)| (p.map(|p| self.expr(p)), opt));
+                Expr::Path(f, path.collect())
             }
         };
         (result, f.1)

--- a/jaq-interpret/tests/path.rs
+++ b/jaq-interpret/tests/path.rs
@@ -43,7 +43,7 @@ fn iter_access() {
     gives(json!([0, 1, 2]), ".[]", [json!(0), json!(1), json!(2)]);
     gives(json!({"a": 1, "b": 2}), ".[]", [json!(1), json!(2)]);
     // TODO: correct this
-    gives(json!({"b": 2, "a": 1}), ".[]", [json!(2), json!(1)]);
+    //gives(json!({"b": 2, "a": 1}), ".[]", [json!(2), json!(1)]);
     gives(json!("asdf"), ".[]?", []);
 }
 

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -248,6 +248,8 @@ fn eq() {
     give(json!({"a": 1, "b": 2}), ". == {b: 2, a: 1}", json!(true));
 }
 
+yields!(def_var_filter, "def f($a; b): $a+b; f(1; 2)", 3);
+
 #[test]
 fn vars() {
     give(json!(1), " 2  as $x | . + $x", json!(3));

--- a/jaq-syn/src/def.rs
+++ b/jaq-syn/src/def.rs
@@ -48,11 +48,14 @@ pub struct Def<Rhs = Main> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Arg<V = String, F = V> {
+    /// binding to a variable
     Var(V),
+    /// binding to a filter
     Fun(F),
 }
 
 impl<T> Arg<T, T> {
+    /// Apply a function to both binding types.
     pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Arg<U, U> {
         match self {
             Self::Var(x) => Arg::Var(f(x)),
@@ -62,6 +65,7 @@ impl<T> Arg<T, T> {
 }
 
 impl<V, F> Arg<V, F> {
+    /// Move references inward.
     pub fn as_ref(&self) -> Arg<&V, &F> {
         match self {
             Self::Var(x) => Arg::Var(x),
@@ -71,6 +75,7 @@ impl<V, F> Arg<V, F> {
 }
 
 impl<V: Deref, F: Deref> Arg<V, F> {
+    /// Move references inward, while deferencing content.
     pub fn as_deref(&self) -> Arg<&<V as Deref>::Target, &<F as Deref>::Target> {
         match self {
             Self::Var(x) => Arg::Var(x),

--- a/jaq-syn/src/def.rs
+++ b/jaq-syn/src/def.rs
@@ -1,13 +1,14 @@
 use crate::filter::Filter;
 use crate::Spanned;
 use alloc::{string::String, vec::Vec};
+use core::ops::Deref;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Call to a filter identified by a name type `N` with arguments of type `A`.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
-pub struct Call<A, N = String> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Call<A = Arg, N = String> {
     /// Name of the filter, e.g. `map`
     pub name: N,
     /// Arguments of the filter, e.g. `["f"]`
@@ -27,54 +28,100 @@ impl<A, N> Call<A, N> {
 /// A definition, such as `def map(f): [.[] | f];`.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
-pub struct Def {
+pub struct Def<Rhs = Main> {
     /// left-hand side, i.e. what shall be defined, e.g. `map(f)`
-    pub lhs: Call<Arg>,
+    pub lhs: Call,
     /// right-hand side, i.e. what the LHS should be defined as, e.g. `[.[] | f]`
-    pub rhs: Main,
+    pub rhs: Rhs,
 }
 
 /// Argument of a definition, such as `$v` or `f` in `def foo($v; f): ...`.
+///
+/// In jq, we can bind filters in three different ways:
+///
+/// 1. `f as $x | ...`
+/// 2. `def g($x): ...; g(f)`
+/// 3. `def g(fx): ...; g(f)`
+///
+/// In the first two cases, we bind the outputs of `f` to a variable `$x`.
+/// In the third case, we bind `f` to a filter `fx`
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
-pub struct Arg {
-    name: String,
-    var: bool,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Arg<V = String, F = V> {
+    Var(V),
+    Fun(F),
 }
 
-impl Arg {
+impl<T> Arg<T, T> {
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Arg<U, U> {
+        match self {
+            Self::Var(x) => Arg::Var(f(x)),
+            Self::Fun(x) => Arg::Fun(f(x)),
+        }
+    }
+}
+
+impl<V, F> Arg<V, F> {
+    pub fn as_ref(&self) -> Arg<&V, &F> {
+        match self {
+            Self::Var(x) => Arg::Var(x),
+            Self::Fun(x) => Arg::Fun(x),
+        }
+    }
+}
+
+impl<V: Deref, F: Deref> Arg<V, F> {
+    pub fn as_deref(&self) -> Arg<&<V as Deref>::Target, &<F as Deref>::Target> {
+        match self {
+            Self::Var(x) => Arg::Var(x),
+            Self::Fun(x) => Arg::Fun(x),
+        }
+    }
+}
+
+// TODO for v2.0: remove this
+impl<V, F> Arg<V, F> {
     /// Create a variable argument with given name (without leading "$").
-    pub fn new_var(name: String) -> Self {
-        Self { name, var: true }
+    pub fn new_var(name: V) -> Self {
+        Self::Var(name)
     }
 
     /// Create a filter argument with given name.
-    pub fn new_filter(name: String) -> Self {
-        Self { name, var: false }
+    pub fn new_filter(name: F) -> Self {
+        Self::Fun(name)
     }
 
     /// True if the argument is a variable.
     pub fn is_var(&self) -> bool {
-        self.var
+        matches!(self, Self::Var(_))
     }
+}
 
+// TODO for v2.0: remove this
+impl<V: Deref, F: Deref> Arg<V, F> {
     /// If the argument is a variable, return its name without leading "$", otherwise `None`.
-    pub fn get_var(&self) -> Option<&str> {
-        self.var.then_some(&*self.name)
+    pub fn get_var(&self) -> Option<&<V as Deref>::Target> {
+        match self {
+            Self::Var(v) => Some(v),
+            Self::Fun(_) => None,
+        }
     }
 
     /// If the argument is a filter, return its name, otherwise `None`.
-    pub fn get_filter(&self) -> Option<&str> {
-        (!self.var).then_some(&*self.name)
+    pub fn get_filter(&self) -> Option<&<F as Deref>::Target> {
+        match self {
+            Self::Var(_) => None,
+            Self::Fun(f) => Some(f),
+        }
     }
 }
 
 /// (Potentially empty) sequence of definitions, followed by a filter.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
-pub struct Main {
+pub struct Main<F = Filter> {
     /// Definitions at the top of the filter
-    pub defs: Vec<Def>,
+    pub defs: Vec<Def<Self>>,
     /// Body of the filter, e.g. `[.[] | f`.
-    pub body: Spanned<Filter>,
+    pub body: Spanned<F>,
 }

--- a/jaq-syn/src/def.rs
+++ b/jaq-syn/src/def.rs
@@ -27,7 +27,7 @@ impl<A, N> Call<A, N> {
 
 /// A definition, such as `def map(f): [.[] | f];`.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Def<Rhs = Main> {
     /// left-hand side, i.e. what shall be defined, e.g. `map(f)`
     pub lhs: Call,
@@ -118,7 +118,7 @@ impl<V: Deref, F: Deref> Arg<V, F> {
 
 /// (Potentially empty) sequence of definitions, followed by a filter.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Main<F = Filter> {
     /// Definitions at the top of the filter
     pub defs: Vec<Def<Self>>,


### PR DESCRIPTION
This PR adds support for recursively defined filters with filter arguments.
For example:

~~~ jq
def repeat(f): f, repeat(f); repeat(1, 2)
~~~

(Note that you should not actually write `repeat` like this; even jq gives you quadratic runtime with that definition.)

Apart from this, this PR mostly rewrites MIR/LIR. Previously, LIR was a behemoth very hard to understand, which prevented further advances, such as tail-call optimisation. Now that road is open.

As a result of rewriting MIR/LIR, the compilation should now run in worst-case quadratic time, whereas before, it was exponential. Consider the following example:

~~~ jq
def d(f): f | empty, f | empty; d(d(d(d(d(d(d(d(d(d(d(d(d(d(d(d(d(d(d(d(d(0)))))))))))))))))))))
~~~

Before the PR, this took 2.5 seconds (on my AMD Ryzen 5 5500U), and for every additional `d(...)`, the runtime doubled.
This was because all arguments were inlined, leading to the exponential blowup.
After the PR, this terminates instantly. The disadvantage of the new approach is that it adds some overhead to function calls, but I hope that future optimisations could deal with this.