### PR TITLE
Save references to filter ASTs as integers, not as pointers

### DIFF
--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -301,7 +301,7 @@ impl<'a> FilterT<'a> for Ref<'a> {
                 }
             }
 
-            Ast::Native(Native { run, .. }, args) => (run)(Args(&args, self.1), cv),
+            Ast::Native(Native { run, .. }, args) => (run)(Args(args, self.1), cv),
         }
     }
 
@@ -358,7 +358,7 @@ impl<'a> FilterT<'a> for Ref<'a> {
                 reduce(cvs, init, move |cv, v| def.update((cv.0, v), f.clone()))
             }
 
-            Ast::Native(Native { update, .. }, args) => (update)(Args(&args, self.1), cv, f),
+            Ast::Native(Native { update, .. }, args) => (update)(Args(args, self.1), cv, f),
         }
     }
 }

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -75,7 +75,7 @@ type Inputs<'i> = RcIter<dyn Iterator<Item = Result<Val, String>> + 'i>;
 #[derive(Clone)]
 pub struct Ctx<'a> {
     /// variable bindings
-    vars: RcList<Bind<Val, (&'a filter::Ast, Self)>>,
+    vars: RcList<Bind<Val, (filter::Id, Self)>>,
     inputs: &'a Inputs<'a>,
 }
 
@@ -93,7 +93,7 @@ impl<'a> Ctx<'a> {
     }
 
     /// Add a new filter binding.
-    pub(crate) fn cons_fun(mut self, f: (&'a filter::Ast, Self)) -> Self {
+    pub(crate) fn cons_fun(mut self, f: (filter::Id, Self)) -> Self {
         self.vars = self.vars.cons(Bind::Fun(f));
         self
     }

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -40,13 +40,13 @@ impl Ctx {
             assert_eq!(id, id_);
         }
 
-        let empty = self.empty();
-        let empty_id = self.id_of_ast(empty);
-        assert_eq!(empty_id, EMPTY);
-
         let arr_obj = self.arr_obj_elems();
         let arr_obj_id = self.id_of_ast(arr_obj);
         assert_eq!(arr_obj_id, ARR_OBJ_ELEMS);
+
+        let empty = self.empty();
+        let empty_id = self.id_of_ast(empty);
+        assert_eq!(empty_id, EMPTY);
     }
 
     /// `{}[]` returns zero values.

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -171,7 +171,7 @@ impl Ctx {
                         let v = match v {
                             None => self.id_of_ast(Filter::Path(
                                 IDENTITY,
-                                Path::from(path::Part::Index(k.clone())),
+                                Path::from(path::Part::Index(k)),
                             )),
                             Some(v) => get(v, self),
                         };

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -1,15 +1,15 @@
 //! Low-level Intermediate Representation of filters.
 
-use crate::filter::{self, AbsId, Ast as Filter, Def};
+use crate::filter::{self, Ast as Filter, Id as AbsId};
 use crate::mir::{self, MirFilter, RelId, Relative};
 use crate::path::{self, Path};
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use jaq_syn::filter::{AssignOp, BinaryOp, Fold, KeyVal};
 use jaq_syn::{MathOp, Str};
 
 #[derive(Default)]
 pub struct Ctx {
-    defs: Vec<Def>,
+    defs: Vec<Filter>,
     callable: Vec<Callable>,
 }
 
@@ -19,26 +19,68 @@ pub struct Callable {
     id: AbsId,
 }
 
+const IDENTITY: AbsId = AbsId(0);
+const TOSTRING: AbsId = AbsId(IDENTITY.0 + 1);
+const ARR_OBJ_ELEMS: AbsId = AbsId(TOSTRING.0 + 1);
+const EMPTY: AbsId = AbsId(ARR_OBJ_ELEMS.0 + 2);
+
 pub fn root_def(def: mir::Def) -> filter::Owned {
     let mut ctx = Ctx::default();
-    ctx.def(def);
-    filter::Owned::new(ctx.defs[0].rhs.clone(), ctx.defs)
+    ctx.init_constants();
+    let id = ctx.def(def);
+    filter::Owned::new(id, ctx.defs)
 }
 
 // TODO: remove itertools dependency
 
 impl Ctx {
+    fn init_constants(&mut self) {
+        for (f, id) in [(Filter::Id, IDENTITY), (Filter::ToString, TOSTRING)] {
+            let id_ = self.id_of_ast(f);
+            assert_eq!(id, id_);
+        }
+
+        let empty = self.empty();
+        let empty_id = self.id_of_ast(empty);
+        assert_eq!(empty_id, EMPTY);
+
+        let arr_obj = self.arr_obj_elems();
+        let arr_obj_id = self.id_of_ast(arr_obj);
+        assert_eq!(arr_obj_id, ARR_OBJ_ELEMS);
+    }
+
+    /// `{}[]` returns zero values.
+    fn empty(&mut self) -> Filter {
+        // `{}`
+        let obj = Filter::Object(Vec::new());
+        // `[]`
+        let path = (path::Part::Range(None, None), path::Opt::Essential);
+        Filter::Path(self.id_of_ast(obj), Path(Vec::from([path])))
+    }
+
+    /// `.[]?` returns array/object elements or nothing instead
+    ///
+    /// `..`, also known as `recurse/0`, is defined as `recurse(.[]?)`
+    fn arr_obj_elems(&mut self) -> Filter {
+        // `[]?`
+        let path = (path::Part::Range(None, None), path::Opt::Optional);
+        // `.[]?`
+        Filter::Path(IDENTITY, Path(Vec::from([path])))
+    }
+
     fn get_callable(&self, RelId(id): RelId) -> &Callable {
         &self.callable[id]
     }
 
-    fn get_def(&mut self, AbsId(id): AbsId) -> &mut Def {
+    fn get_def(&mut self, AbsId(id): AbsId) -> &mut Filter {
         &mut self.defs[id]
     }
 
     fn main(&mut self, main: mir::Main) -> Filter {
         let defs_len = main.defs.len();
-        main.defs.into_iter().for_each(|def| self.def(def));
+        main.defs.into_iter().for_each(|def| {
+            self.def(def);
+        });
         let body = self.filter(main.body);
 
         self.callable
@@ -48,35 +90,44 @@ impl Ctx {
         body
     }
 
-    fn def(&mut self, def: mir::Def) {
+    fn def(&mut self, def: mir::Def) -> AbsId {
         let id = AbsId(self.defs.len());
-        self.defs.push(Def {
-            rhs: Filter::default(),
-        });
+        self.defs.push(Filter::default());
         self.callable.push(Callable {
             typ: Relative::Parent,
             sig: def.lhs.clone(),
             id,
         });
-        self.get_def(id).rhs = self.main(def.rhs);
+        *self.get_def(id) = self.main(def.rhs);
         let last = self.callable.last_mut().unwrap();
         assert!(last.id == id);
         last.typ = Relative::Sibling;
+        id
+    }
+
+    fn id_of_ast(&mut self, f: filter::Ast) -> AbsId {
+        let len = self.defs.len();
+        self.defs.push(f);
+        AbsId(len)
     }
 
     /// Convert a MIR filter to a LIR filter.
     fn filter(&mut self, f: MirFilter) -> Filter {
-        let get = |f, ctx: &mut Self| Box::new(ctx.filter(f));
+        let get = |f, ctx: &mut Self| {
+            let f = ctx.filter(f);
+            ctx.id_of_ast(f)
+        };
         let of_str = |s: Str<_>, ctx: &mut Self| {
-            let fmt = s.fmt.map_or(Filter::ToString, |fmt| *get(*fmt, ctx));
+            let fmt = s.fmt.map_or(TOSTRING, |fmt| get(*fmt, ctx));
             use jaq_syn::string::Part;
-            let mut iter = s.parts.into_iter().rev().map(|part| match part {
+            let iter = s.parts.into_iter().map(|part| match part {
                 Part::Str(s) => Filter::Str(s),
-                Part::Fun(f) => Filter::Pipe(Box::new(*get(f, ctx)), false, Box::new(fmt.clone())),
+                Part::Fun(f) => Filter::Pipe(get(f, ctx), false, fmt),
             });
+            let mut iter = iter.collect::<Vec<_>>().into_iter().rev();
             let last = iter.next();
             iter.fold(last.unwrap_or_else(|| Filter::Str("".into())), |acc, x| {
-                Filter::Math(Box::new(x), MathOp::Add, Box::new(acc))
+                Filter::Math(ctx.id_of_ast(x), MathOp::Add, ctx.id_of_ast(acc))
             })
         };
         use mir::Filter as Expr;
@@ -84,7 +135,7 @@ impl Ctx {
         match f.0 {
             Expr::Var(v) => Filter::Var(v),
             Expr::Call(call, args) => {
-                let args: Vec<_> = args.into_iter().map(|a| *get(a, self)).collect();
+                let args: Vec<_> = args.into_iter().map(|a| get(a, self)).collect();
                 match call {
                     mir::Call::Arg(a) if args.is_empty() => Filter::Var(a),
                     mir::Call::Arg(_) => panic!("higher-order argument encountered"),
@@ -110,29 +161,28 @@ impl Ctx {
             Expr::Num(mir::Num::Float(f)) => Filter::Float(f),
             Expr::Num(mir::Num::Int(i)) => Filter::Int(i),
             Expr::Str(s) => of_str(*s, self),
-            Expr::Array(a) => {
-                Filter::Array(a.map_or_else(|| Box::new(Filter::empty()), |a| get(*a, self)))
-            }
+            Expr::Array(a) => Filter::Array(a.map_or(EMPTY, |a| get(*a, self))),
             Expr::Object(o) => {
                 let kvs = o.into_iter().map(|kv| match kv {
-                    KeyVal::Filter(k, v) => (*get(k, self), *get(v, self)),
+                    KeyVal::Filter(k, v) => (get(k, self), get(v, self)),
                     KeyVal::Str(k, v) => {
                         let k = of_str(k, self);
+                        let k = self.id_of_ast(k);
                         let v = match v {
-                            None => Filter::Path(
-                                Box::new(Filter::Id),
+                            None => self.id_of_ast(Filter::Path(
+                                IDENTITY,
                                 Path::from(path::Part::Index(k.clone())),
-                            ),
-                            Some(v) => *get(v, self),
+                            )),
+                            Some(v) => get(v, self),
                         };
                         (k, v)
                     }
                 });
                 Filter::Object(kvs.collect())
             }
-            Expr::Try(f) => Filter::Try(get(*f, self), Box::new(Filter::empty())),
+            Expr::Try(f) => Filter::Try(get(*f, self), EMPTY),
             Expr::Neg(f) => Filter::Neg(get(*f, self)),
-            Expr::Recurse => Filter::recurse0(),
+            Expr::Recurse => Filter::Recurse(ARR_OBJ_ELEMS),
 
             Expr::Binary(l, op, r) => {
                 let (l, r) = (get(*l, self), get(*r, self));
@@ -151,23 +201,22 @@ impl Ctx {
             }
 
             Expr::Ite(if_thens, else_) => {
-                let else_ = else_.map_or(Filter::Id, |else_| *get(*else_, self));
+                let else_ = else_.map_or(Filter::Id, |else_| self.filter(*else_));
                 if_thens.into_iter().rev().fold(else_, |acc, (if_, then_)| {
-                    Filter::Ite(get(if_, self), get(then_, self), Box::new(acc))
+                    Filter::Ite(get(if_, self), get(then_, self), self.id_of_ast(acc))
                 })
             }
-            Expr::TryCatch(try_, catch_) => Filter::Try(
-                get(*try_, self),
-                catch_.map_or_else(|| Box::new(Filter::empty()), |c| get(*c, self)),
-            ),
+            Expr::TryCatch(try_, catch_) => {
+                Filter::Try(get(*try_, self), catch_.map_or(EMPTY, |c| get(*c, self)))
+            }
             Expr::Path(f, path) => {
                 let f = get(*f, self);
                 use jaq_syn::path::Part;
                 let path = path.into_iter().map(|(p, opt)| match p {
-                    Part::Index(i) => (path::Part::Index(*get(i, self)), opt),
+                    Part::Index(i) => (path::Part::Index(get(i, self)), opt),
                     Part::Range(lower, upper) => {
-                        let lower = lower.map(|f| *get(f, self));
-                        let upper = upper.map(|f| *get(f, self));
+                        let lower = lower.map(|f| get(f, self));
+                        let upper = upper.map(|f| get(f, self));
                         (path::Part::Range(lower, upper), opt)
                     }
                 });


### PR DESCRIPTION
Before this change, a filter AST referred to its sub-expressions by a `Box`.
After this change, a filter AST refers to its sub-expressions by an index into a `Vec`.

This is indispensable for implementing full tail-recursion optimisation (TCO) within the current API.
Consider the following example:

~~~ jq
def repeat(f): f, repeat(f); repeat(1, 2)
~~~

Here, when we call `repeat(f)` from within `repeat(f)`, we will want to return a value that is caught by the original call to `repeat(1, 2)`, and we want to pass this the information that we called it with the argument `f`.
However, because `f` was previously a pointer to a sub-expression, returning it would have needed adding a lifetime to the return value (`ValR`), which would have broken the API.

The new system also has the advantage that we are just generalising a mechanism that already existed; in particular, definitions were already referred to as indices inside a definition `Vec`. Now, all (sub-)expressions are stored in this `Vec`.

I was hoping that perhaps due to cache-locality of `Vec`, the performance would improve, but this does not seem to be the case. Performance is pretty much like before this change.