### PR TITLE
Generate objects lazily & remove itertools dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,6 @@ dependencies = [
  "dyn-clone",
  "hifijson",
  "indexmap",
- "itertools",
  "jaq-parse",
  "jaq-syn",
  "once_cell",

--- a/jaq-interpret/Cargo.toml
+++ b/jaq-interpret/Cargo.toml
@@ -21,7 +21,6 @@ ahash = "0.7.6"
 dyn-clone = "1.0"
 hifijson = { version = "0.2.0", optional = true }
 indexmap = "2.0"
-itertools = "0.10.3"
 once_cell = "1.16.0"
 serde_json = { version = "1.0.81", optional = true }
 

--- a/jaq-interpret/src/lib.rs
+++ b/jaq-interpret/src/lib.rs
@@ -191,6 +191,7 @@ impl ParseCtx {
 
         let inputs = RcIter::new(core::iter::empty());
         let out = f.run((Ctx::new([], &inputs), x));
-        itertools::assert_equal(out, ys);
+
+        assert!(out.eq(ys))
     }
 }

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -31,8 +31,6 @@ pub fn root_def(def: mir::Def) -> filter::Owned {
     filter::Owned::new(id, ctx.defs)
 }
 
-// TODO: remove itertools dependency
-
 impl Ctx {
     fn init_constants(&mut self) {
         for (f, id) in [(Filter::Id, IDENTITY), (Filter::ToString, TOSTRING)] {

--- a/jaq-interpret/src/path.rs
+++ b/jaq-interpret/src/path.rs
@@ -202,8 +202,8 @@ fn prod<'a, T: 'a + Clone>(
     l: impl Iterator<Item = T> + 'a,
     r: impl Iterator<Item = T> + 'a,
 ) -> impl Iterator<Item = (T, T)> + 'a {
-    use itertools::Itertools;
-    l.cartesian_product(r.collect::<Vec<T>>())
+    let r: Vec<_> = r.collect();
+    l.flat_map(move |l| r.clone().into_iter().map(move |r| (l.clone(), r)))
 }
 
 fn skip_take(from: usize, until: usize) -> (usize, usize) {


### PR DESCRIPTION
This PR makes evaluation of object keys/values lazy.

Previously, the following filter would never yield a single result:

~~~ jq
'{("a", "b"): (0 | recurse(.+1)), ("c", "d"): 2}'
~~~

Now, it generates an infinite stream of objects, just like jq.

How's performance? Let's test it with the following filter:

~~~ jq
limit(1000000; {("a", "b"): (0 | recurse(.+1)), ("c", "d"): 2}) | empty
~~~

jq 1.7 takes 1.1 seconds, whereas jaq takes only 0.5 seconds! :)

As a bonus, this also eliminates the dependency of `jaq-interpret` on `itertools`.