### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 jaq (pronounced like *Jacques*[^jacques]) is a clone of the JSON data processing tool [jq].
 jaq aims to support a large subset of jq's syntax and operations.
 
-jaq focusses on three goals:
+jaq focuses on three goals:
 
 * **Correctness**:
   jaq aims to provide a more correct and predictable implementation of jq,
@@ -668,7 +668,7 @@ loops
 however doesn't interrupt the `f` stream, but instead sends _each_
 error value emitted to the `g` filter; the result is a stream of
 values emitted from `f` with values emitted from `g` interspersed
-where errors ocurred.
+where errors occurred.
 
 Consider the following example: this expression is `true` in jq,
 because the first `error(2)` interrupts the stream:

--- a/jaq-syn/src/def.rs
+++ b/jaq-syn/src/def.rs
@@ -75,7 +75,7 @@ impl<V, F> Arg<V, F> {
 }
 
 impl<V: Deref, F: Deref> Arg<V, F> {
-    /// Move references inward, while deferencing content.
+    /// Move references inward, while dereferencing content.
     pub fn as_deref(&self) -> Arg<&<V as Deref>::Target, &<F as Deref>::Target> {
         match self {
             Self::Var(x) => Arg::Var(x),


### PR DESCRIPTION
Easy fixes by running `typos -w`.

[`typos`](https://github.com/crate-ci/typos) is an awesome tool written in Rust :D