### PR TITLE
Add env filter

### DIFF
--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -360,7 +360,16 @@ fn now() -> Result<f64, Error> {
 }
 
 #[cfg(feature = "std")]
-const STD: &[(&str, usize, RunPtr)] = &[("now", 0, |_, _| box_once(now().map(Val::Float)))];
+const STD: &[(&str, usize, RunPtr)] = &[
+    ("env", 0, |_, _| {
+        box_once(Ok(Val::obj(
+            std::env::vars()
+                .map(|(k, v)| (Rc::new(k), Val::str(v)))
+                .collect(),
+        )))
+    }),
+    ("now", 0, |_, _| box_once(now().map(Val::Float))),
+];
 
 #[cfg(feature = "parse_json")]
 /// Convert string to a single JSON value.

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -218,6 +218,14 @@ fn binds(cli: &Cli) -> Result<Vec<(String, Val)>, Error> {
     })?;
 
     var_val.push(("ARGS".to_string(), args_named(&var_val)));
+    var_val.push((
+        "ENV".to_string(),
+        Val::obj(
+            std::env::vars()
+                .map(|(k, v)| (k.into(), Val::str(v)))
+                .collect(),
+        ),
+    ));
 
     Ok(var_val)
 }


### PR DESCRIPTION
This PR adds the `env` filter. ~The `$ENV` global variable is not included in this PR yet, mostly because I didn't find a clean way of embedding it into global scope.~

It also adds the `$ENV` variable as an additional binding in the jaq CLI.

Reference: <https://jqlang.github.io/jq/manual/#$env-env>