### PR TITLE
Next-gen `group_by`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,12 +149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,15 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,7 +268,6 @@ dependencies = [
  "aho-corasick",
  "base64",
  "hifijson",
- "itertools",
  "jaq-interpret",
  "jaq-parse",
  "libm",

--- a/jaq-core/Cargo.toml
+++ b/jaq-core/Cargo.toml
@@ -27,7 +27,6 @@ libm = { version = "0.2.7", optional = true }
 aho-corasick = { version = "1.0", optional = true }
 base64 = { version = "0.21.2", optional = true }
 urlencoding = { version = "2.1.3", optional = true }
-itertools = "0.10.3"
 
 [dev-dependencies]
 jaq-parse = { version = "1.0.0", path = "../jaq-parse" }

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -99,14 +99,10 @@ fn sort_by<'a>(xs: &mut [Val], f: impl Fn(Val) -> ValRs<'a>) -> Result<(), Error
 
 /// Group an array by the given function.
 fn group_by<'a>(xs: Vec<Val>, f: impl Fn(Val) -> ValRs<'a>) -> ValR {
-    let mut err = None;
-    let mut yx = xs
+    let mut yx: Vec<(Vec<Val>, Val)> = xs
         .into_iter()
-        .map(|x| (run_if_ok(x.clone(), &mut err, &f), x))
-        .collect::<Vec<(Vec<Val>, Val)>>();
-    if let Some(err) = err {
-        return Err(err);
-    }
+        .map(|x| Ok((f(x.clone()).collect::<Result<_, _>>()?, x)))
+        .collect::<Result<_, _>>()?;
 
     yx.sort_by(|(y1, _), (y2, _)| y1.cmp(y2));
 


### PR DESCRIPTION
This rewrites `group_by` to 1) terminate as soon as an error is encountered and to 2) remove the dependency on `itertools`.

The runtime of `group_by` slightly increases by about 4%:

~~~
$ hyperfine -L jq ./jaq-before,target/release/jaq,./jq-linux-amd64-1.7 '{jq} -n "[range(0; 1000000)] | group_by(. % 2) | empty"'
Benchmark 1: ./jaq-before -n "[range(0; 1000000)] | group_by(. % 2) | empty"
  Time (mean ± σ):     492.0 ms ±   2.4 ms    [User: 411.1 ms, System: 80.6 ms]
  Range (min … max):   487.0 ms … 494.9 ms    10 runs
 
Benchmark 2: target/release/jaq -n "[range(0; 1000000)] | group_by(. % 2) | empty"
  Time (mean ± σ):     511.5 ms ±   1.5 ms    [User: 427.2 ms, System: 84.1 ms]
  Range (min … max):   509.0 ms … 514.1 ms    10 runs
 
Benchmark 3: ./jq-linux-amd64-1.7 -n "[range(0; 1000000)] | group_by(. % 2) | empty"
  Time (mean ± σ):      1.952 s ±  0.006 s    [User: 1.855 s, System: 0.097 s]
  Range (min … max):    1.945 s …  1.963 s    10 runs
 
Summary
  './jaq-before -n "[range(0; 1000000)] | group_by(. % 2) | empty"' ran
    1.04 ± 0.01 times faster than 'target/release/jaq -n "[range(0; 1000000)] | group_by(. % 2) | empty"'
    3.97 ± 0.02 times faster than './jq-linux-amd64-1.7 -n "[range(0; 1000000)] | group_by(. % 2) | empty"'
~~~

But as we can see, it is still way faster than jq 1.7. So this is fine.