### PR TITLE
Recursive object merge

### DIFF
--- a/jaq-interpret/src/val.rs
+++ b/jaq-interpret/src/val.rs
@@ -389,6 +389,17 @@ impl core::ops::Mul for Val {
             (Str(_), Int(_)) | (Int(_), Str(_)) => Ok(Null),
             (Num(n), r) => Self::from_dec_str(&n) * r,
             (l, Num(n)) => l * Self::from_dec_str(&n),
+            (Obj(mut l), Obj(r)) => {
+                let inner = Rc::make_mut(&mut l);
+                for (k, v) in r.iter() {
+                    let merged = match (inner.get(k), v) {
+                        (Some(nl @ Obj(_)), nr @ Obj(_)) => nl.clone() * nr.clone(),
+                        _ => Ok(v.clone()),
+                    }?;
+                    inner.insert(k.clone(), merged);
+                }
+                Ok(Obj(l))
+            }
             (l, r) => Err(Error::MathOp(l, MathOp::Mul, r)),
         }
     }

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -54,6 +54,11 @@ fn mul() {
 
     give(json!("Hello"), "0 * .", json!(null));
     give(json!(-1), ". * \"Hello\"", json!(null));
+    give(
+        json!({"k": {"a": 1, "b": 2}}),
+        ". * {k: {a: 0, c: 3}}",
+        json!({"k": {"a": 0, "b": 2, "c": 3}}),
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR implements `*` for objects, according to the spec here: <https://jqlang.github.io/jq/manual/#multiplication-division-modulo>