### PR TITLE
Lazier core filters

### DIFF
--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -378,11 +378,8 @@ fn now() -> Result<f64, Error> {
 #[cfg(feature = "std")]
 const STD: &[(&str, usize, RunPtr)] = &[
     ("env", 0, |_, _| {
-        box_once(Ok(Val::obj(
-            std::env::vars()
-                .map(|(k, v)| (Rc::new(k), Val::str(v)))
-                .collect(),
-        )))
+        let vars = std::env::vars().map(|(k, v)| (Rc::new(k), Val::str(v)));
+        once_with(|| Ok(Val::obj(vars.collect())))
     }),
     ("now", 0, |_, _| once_with(|| now().map(Val::Float))),
 ];

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -253,7 +253,7 @@ const CORE_RUN: &[(&str, usize, RunPtr)] = &[
         once_with(move || Ok(Val::str(cv.1.to_string())))
     }),
     ("utf8bytelength", 0, |_, cv| {
-        once_with(move || cv.1.as_str().and_then(|s| Ok(Val::Int(s.len() as isize))))
+        once_with(move || cv.1.as_str().map(|s| Val::Int(s.len() as isize)))
     }),
     ("explode", 0, |_, cv| {
         once_with(move || cv.1.as_str().and_then(|s| Ok(Val::arr(explode(s)?))))

--- a/jaq-core/src/math.rs
+++ b/jaq-core/src/math.rs
@@ -10,7 +10,7 @@ pub fn as_i32(v: &Val) -> Result<i32, Error> {
 macro_rules! math_0_ary {
     ($name: expr, $f: ident, $domain: expr, $codomain: expr) => {
         ($name, 0, |_, cv| {
-            box_once($domain(&cv.1).map(libm::$f).map($codomain))
+            once_with(move || $domain(&cv.1).map(libm::$f).map($codomain))
         })
     };
 }

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -68,13 +68,8 @@ fn explode_implode() {
     give(json!([1114112]), "try implode catch -1", json!(-1));
 }
 
-#[test]
-fn first_last() {
-    gives(json!([]), "first(.[])", []);
-    gives(json!([]), "last(.[])", []);
-    give(json!([1, 2, 3]), "first(.[])", json!(1));
-    give(json!([1, 2, 3]), "last(.[])", json!(3));
-}
+yields!(first_empty, "[first({}[])]", json!([]));
+yields!(first_some, "first(1, 2, 3)", 1);
 
 yields!(
     format_text,

--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -92,7 +92,7 @@ def first:  .[ 0];
 def last:   .[-1];
 def nth(n): .[ n];
 
-def last(g): reduce g as $item (null; $item);
+def last(g): reduce g as $item ([]; [$item]) | .[];
 def nth(n; g): last(limit(n + 1; g));
 
 # Objects <-> Arrays

--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -92,6 +92,7 @@ def first:  .[ 0];
 def last:   .[-1];
 def nth(n): .[ n];
 
+def last(g): reduce g as $item (null; $item);
 def nth(n; g): last(limit(n + 1; g));
 
 # Objects <-> Arrays

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -155,7 +155,8 @@ yields!(
     ["abc", "az", "fax", "foo"]
 );
 
-yields!(last_empty, "last({}[])", json!(null));
+// this diverges from jq, which returns [null]
+yields!(last_empty, "[last({}[])]", json!([]));
 yields!(last_some, "last(1, 2, 3)", 3);
 
 yields!(logb_inf, "infinite | logb | . == infinite", true);

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -155,6 +155,9 @@ yields!(
     ["abc", "az", "fax", "foo"]
 );
 
+yields!(last_empty, "last({}[])", json!(null));
+yields!(last_some, "last(1, 2, 3)", 3);
+
 yields!(logb_inf, "infinite | logb | . == infinite", true);
 yields!(logb_nan, "nan | logb | isnan", true);
 yields!(logb_neg_inf, "-infinite | logb | . == infinite", true);

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -218,14 +218,8 @@ fn binds(cli: &Cli) -> Result<Vec<(String, Val)>, Error> {
     })?;
 
     var_val.push(("ARGS".to_string(), args_named(&var_val)));
-    var_val.push((
-        "ENV".to_string(),
-        Val::obj(
-            std::env::vars()
-                .map(|(k, v)| (k.into(), Val::str(v)))
-                .collect(),
-        ),
-    ));
+    let env = std::env::vars().map(|(k, v)| (k.into(), Val::str(v)));
+    var_val.push(("ENV".to_string(), Val::obj(env.collect())));
 
     Ok(var_val)
 }


### PR DESCRIPTION
This PR delays the execution of many core filters.
For example, before this change, the filter `1, debug` printed:

~~~
[DEBUG] null
1
null
~~~

After this change, this prints:

~~~
1
[DEBUG] null
null
~~~

This is more consistent with jq, which yields:

~~~
1
["DEBUG:",null]
null
~~~

In some cases, this makes filters terminate which did not terminate before. For example,

~~~ jq
[0, 1] | first(1, sort_by(repeat(0)))
~~~

yielded no single output before, because `sort_by` was executed before 1 was yielded. With this PR, jaq yields 1 (just like jq).

Previously, also the `last/1` filter was executed strictly. With this PR, it is implemented by definition in a naturally lazy way.
This makes the `bf-fib` benchmark a bit slower (runtime decreases from 414.8 ms to 485.3 ms), but it remains still a lot faster than in jq or gojq. This also makes the evaluation fairer, because jq also implements `last/1` by definition.