### PR TITLE
Added support for WASIX and published it to Wasmer!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ resolver = "2"
 
 [profile.release]
 strip = true
-codegen-units = 1
+opt-level = 'z'
+lto = true

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ jaq should work on any system supported by Rust.
 If it does not, please file an issue.
 
 
+You can also use [Wasmer](https://wasmer.io) to run `jaq` without an
+installation required, using the [jaq/jaq package](https://wasmer.io/jaq/jaq):
+
+    $ echo '{"a": 1, "b": 2}' | wasmer run jaq/jaq
+
+
 ## Binaries
 
 You may also install jaq using [homebrew](https://formulae.brew.sh/formula/jaq) on macOS or Linux:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ If it does not, please file an issue.
 You can also use [Wasmer](https://wasmer.io) to run `jaq` without an
 installation required, using the [jaq/jaq package](https://wasmer.io/jaq/jaq):
 
-    $ echo '{"a": 1, "b": 2}' | wasmer run jaq/jaq
+    $ echo '{"a": 1, "b": 2}' | wasmer run jaq/jaq '.a'
+
+    $ seq 1000 | wasmer run jaq/jaq -- -n 'foreach inputs as $x (0; . + $x)'
 
 
 ## Binaries

--- a/build-wasmer.sh
+++ b/build-wasmer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# You'll need to have Cargo WASIX installed (`cargo install cargo-wasix`)
+cargo wasix build --release --no-default-features
+
+# Then, for publishing
+# wasmer publish

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'jaq/jaq'
-version = '0.1.0'
+version = '0.1.1'
 description = 'Just another JSON query tool'
 README = "README.md"
 

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,8 +1,8 @@
 [package]
 name = 'jaq/jaq'
-version = '0.1.2'
+version = '0.1.3'
 description = 'Just another JSON query tool'
-README = "README.md"
+readme = "README.md"
 repository = "https://github.com/01mf02/jaq"
 
 # See more keys and definitions at https://docs.wasmer.io/registry/manifest

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -2,6 +2,7 @@
 name = 'jaq/jaq'
 version = '0.1.0'
 description = 'Just another JSON query tool'
+README = "README.md"
 
 # See more keys and definitions at https://docs.wasmer.io/registry/manifest
 

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,8 +1,9 @@
 [package]
 name = 'jaq/jaq'
-version = '0.1.1'
+version = '0.1.2'
 description = 'Just another JSON query tool'
 README = "README.md"
+repository = "https://github.com/01mf02/jaq"
 
 # See more keys and definitions at https://docs.wasmer.io/registry/manifest
 

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,0 +1,15 @@
+[package]
+name = 'jaq/jaq'
+version = '0.1.0'
+description = 'Just another JSON query tool'
+
+# See more keys and definitions at https://docs.wasmer.io/registry/manifest
+
+[[module]]
+name = 'jaq'
+source = 'target/wasm32-wasmer-wasi/release/jaq.wasm'
+abi = 'wasi'
+
+[[command]]
+name = 'jaq'
+module = 'jaq'


### PR DESCRIPTION
First of all, congrats on the awesome work... love what you are doing!

I compiled the project to [WASIX](https://wasix.org) to allow running `jaq` anywhere via WebAssembly (even on the browser!). I also published under [jaq/jaq](https://wasmer.io/jaq/jaq) in [Wasmer](https://wasmer.io) (please let me know if you have a Wasmer username so I can add you to the namespace).

This PR is fairly simple, but it allows running jaq just with `wasmer`:

```bash
echo '{"a": 1, "b": 2}' | wasmer run jaq/jaq '.a'
```

I'm happy to add CI integration as well, so it's automatically published in the future. Just let me know!