### PR TITLE
Fix path parsing for expressions like `.a.[]`

### DIFF
--- a/jaq-interpret/tests/path.rs
+++ b/jaq-interpret/tests/path.rs
@@ -41,6 +41,8 @@ fn index_access() {
 #[test]
 fn iter_access() {
     gives(json!([0, 1, 2]), ".[]", [json!(0), json!(1), json!(2)]);
+    gives(json!({"a": [1, 2]}), ".a[]", [json!(1), json!(2)]);
+    gives(json!({"a": [1, 2]}), ".a.[]", [json!(1), json!(2)]);
     gives(json!({"a": 1, "b": 2}), ".[]", [json!(1), json!(2)]);
     // TODO: correct this
     //gives(json!({"b": 2, "a": 1}), ".[]", [json!(2), json!(1)]);


### PR DESCRIPTION
Should close #134 