### PR TITLE
feat: teach alternation update-assignment operator (`//=`)

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -16,6 +16,12 @@ jobs:
     - name: Check jaq-core
       working-directory: jaq-core
       run: cargo check
+    - name: Check jaq-syn
+      working-directory: jaq-syn
+      run: cargo check
+    - name: Check jaq-interpret
+      working-directory: jaq-interpret
+      run: cargo check
 
     - uses: dtolnay/rust-toolchain@1.64
     - name: Check jaq-std

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Here is an overview that summarises:
 ## Basics
 
 - [x] Identity (`.`)
-- [x] Recursion (`..`)
+- [x] Recursive descent (`..`)
 - [x] Basic data types (null, boolean, number, string, array, object)
 - [x] if-then-else (`if .a < .b then .a else .b end`)
 - [x] Folding (`reduce .[] as $x (0; . + $x)`, `foreach .[] as $x (0; . + $x; . + .)`)
@@ -229,9 +229,9 @@ Here is an overview that summarises:
 - [x] Plain assignment (`=`)
 - [x] Update assignment (`|=`, `+=`, `-=`)
 - [x] Alternation (`//`)
-- [x] Logic (`or`, `and`)
+- [x] Logical (`or`, `and`)
 - [x] Equality and comparison (`.a == .b`, `.a < .b`)
-- [x] Arithmetic (`+`, `-`, `*`, `/`, `%`)
+- [x] Arithmetical (`+`, `-`, `*`, `/`, `%`)
 - [x] Negation (`-`)
 - [x] Error suppression (`?`)
 
@@ -277,7 +277,7 @@ Their definitions are at [`std.jq`](jaq-std/src/std.jq).
 - [x] Array filters (`transpose`, `first`, `last`, `nth(10)`, `flatten`, `min`, `max`)
 - [x] Object-array conversion (`to_entries`, `from_entries`, `with_entries`)
 - [x] Universal/existential (`all`, `any`)
-- [x] Recursion (`walk`)
+- [x] Recursive application (`walk`)
 - [x] I/O (`input`)
 - [x] Regular expressions (`test`, `scan`, `match`, `capture`, `splits`, `sub`, `gsub`)
 - [x] Time (`fromdate`, `todate`)

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -47,21 +47,34 @@ impl Owned {
 /// Function from a value to a stream of value results.
 #[derive(Clone, Debug, Default)]
 pub(crate) enum Ast {
+    /// Nullary identity operation (`.`)
     #[default]
     Id,
     ToString,
 
+    /// Integer value literal
     Int(isize),
+    /// Floating point value literal
     Float(f64),
+    /// String value literal
     Str(String),
+    /// Array value literal (`[f]`)
     Array(Id),
+    /// Object value literal (`{}`, `{(f): g, …}`)
     Object(Vec<(Id, Id)>),
 
+    /// Try-catch (`try f catch g`)
     Try(Id, Id),
+    /// Unary negation operation (`-f`)
     Neg(Id),
+    /// Binary binding operation (`f as $VAR | g`) if identifier (`VAR`) is
+    /// given, otherwise binary application operation (`f | g`)
     Pipe(Id, bool, Id),
+    /// Binary concatenation operation (`f, g`)
     Comma(Id, Id),
+    /// Binary alternation operation (`f // g`)
     Alt(Id, Id),
+    /// If-then-else (`if f then g else h end`)
     Ite(Id, Id, Id),
     /// `reduce`, `for`, and `foreach`
     ///
@@ -88,17 +101,29 @@ pub(crate) enum Ast {
     /// ~~~
     Fold(FoldType, Id, Id, Id),
 
+    /// Path
     Path(Id, crate::path::Path<Id>),
 
+    /// Assignment operation (`f = g`)
     Assign(Id, Id),
+    /// Update-assignment operation (`f |= g`)
     Update(Id, Id),
+    /// Arithmetical update-assignment operation (`f += g`, `f -= g`, `f *= g`,
+    /// `f /= g`, `f %= g`, …)
     UpdateMath(Id, MathOp, Id),
 
+    /// Binary logical operation (`f and g`, `f or g`)
     Logic(Id, bool, Id),
+    /// Binary arithmetical operation (`f + g`, `f - g`, `f * g`, `f / g`,
+    /// `f % g`, …)
     Math(Id, MathOp, Id),
+    /// Binary comparative operation (`f < g`, `f <= g`, `f > g`, `f >= g`,
+    /// `f == g`, `f != g`, …)
     Ord(Id, OrdOp, Id),
 
+    /// Bound variable reference (`$x`)
     Var(usize),
+    /// Call to a filter (`filter`, `filter(…)`)
     Call(Call),
 
     Native(Native, Vec<Id>),

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -108,6 +108,8 @@ pub(crate) enum Ast {
     Assign(Id, Id),
     /// Update-assignment operation (`f |= g`)
     Update(Id, Id),
+    /// Alternation update-assignment operation (`f //= g`)
+    AltUpdate(Id, Id),
     /// Arithmetical update-assignment operation (`f += g`, `f -= g`, `f *= g`,
     /// `f /= g`, `f %= g`, …)
     UpdateMath(Id, MathOp, Id),
@@ -309,6 +311,12 @@ impl<'a> FilterT<'a> for Ref<'a> {
                 (cv.0.clone(), cv.1),
                 Box::new(move |v| w(f).run((cv.0.clone(), v))),
             ),
+            Ast::AltUpdate(path, f) => w(f).pipe(cv, move |cv, y| {
+                w(path).update(
+                    cv,
+                    Box::new(move |x| box_once(Ok(if x.as_bool() { x } else { y.clone() }))),
+                )
+            }),
             Ast::UpdateMath(path, op, f) => w(f).pipe(cv, move |cv, y| {
                 w(path).update(cv, Box::new(move |x| box_once(op.run(x, y.clone()))))
             }),
@@ -378,11 +386,10 @@ impl<'a> FilterT<'a> for Ref<'a> {
             Ast::Int(_) | Ast::Float(_) | Ast::Str(_) => err,
             Ast::Array(_) | Ast::Object(_) => err,
             Ast::Neg(_) | Ast::Logic(..) | Ast::Math(..) | Ast::Ord(..) => err,
-            Ast::Assign(..) | Ast::Update(..) | Ast::UpdateMath(..) => err,
+            Ast::Assign(..) | Ast::Update(..) | Ast::AltUpdate(..) | Ast::UpdateMath(..) => err,
 
-            // these are up for grabs to implement :)
-            Ast::Try(..) | Ast::Alt(..) => todo!(),
-            Ast::Fold(..) => todo!(),
+            Ast::Try(..) | Ast::Alt(..) => todo!("these are up for grabs to implement :)"),
+            Ast::Fold(..) => todo!("these are up for grabs to implement :)"),
 
             Ast::Id => f(cv.1),
             Ast::Path(l, path) => w(l).update(

--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -90,9 +90,9 @@ pub(crate) enum Ast {
 
     Path(Id, crate::path::Path<Id>),
 
+    Assign(Id, Id),
     Update(Id, Id),
     UpdateMath(Id, MathOp, Id),
-    Assign(Id, Id),
 
     Logic(Id, bool, Id),
     Math(Id, MathOp, Id),
@@ -277,15 +277,15 @@ impl<'a> FilterT<'a> for Ref<'a> {
                     outs.flat_map(|vals| then(vals, |vals| Box::new(vals.into_iter().map(Ok)))),
                 )
             }),
+            Ast::Assign(path, f) => w(f).pipe(cv, move |cv, y| {
+                w(path).update(cv, Box::new(move |_| box_once(Ok(y.clone()))))
+            }),
             Ast::Update(path, f) => w(path).update(
                 (cv.0.clone(), cv.1),
                 Box::new(move |v| w(f).run((cv.0.clone(), v))),
             ),
             Ast::UpdateMath(path, op, f) => w(f).pipe(cv, move |cv, y| {
                 w(path).update(cv, Box::new(move |x| box_once(op.run(x, y.clone()))))
-            }),
-            Ast::Assign(path, f) => w(f).pipe(cv, move |cv, y| {
-                w(path).update(cv, Box::new(move |_| box_once(Ok(y.clone()))))
             }),
             Ast::Logic(l, stop, r) => w(l).pipe(cv, move |cv, l| {
                 if l.as_bool() == *stop {
@@ -353,7 +353,7 @@ impl<'a> FilterT<'a> for Ref<'a> {
             Ast::Int(_) | Ast::Float(_) | Ast::Str(_) => err,
             Ast::Array(_) | Ast::Object(_) => err,
             Ast::Neg(_) | Ast::Logic(..) | Ast::Math(..) | Ast::Ord(..) => err,
-            Ast::Update(..) | Ast::UpdateMath(..) | Ast::Assign(..) => err,
+            Ast::Assign(..) | Ast::Update(..) | Ast::UpdateMath(..) => err,
 
             // these are up for grabs to implement :)
             Ast::Try(..) | Ast::Alt(..) => todo!(),

--- a/jaq-interpret/src/lir.rs
+++ b/jaq-interpret/src/lir.rs
@@ -222,6 +222,7 @@ impl Ctx {
                     BinaryOp::Ord(op) => Filter::Ord(l, op, r),
                     BinaryOp::Assign(AssignOp::Assign) => Filter::Assign(l, r),
                     BinaryOp::Assign(AssignOp::Update) => Filter::Update(l, r),
+                    BinaryOp::Assign(AssignOp::AltUpdate) => Filter::AltUpdate(l, r),
                     BinaryOp::Assign(AssignOp::UpdateWith(op)) => Filter::UpdateMath(l, op, r),
                 }
             }

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -9,8 +9,8 @@ use serde_json::json;
 fn update_assign() {
     let ab = |v| json!({"a": v, "b": 2});
     gives(ab(1), ".a  = (.a, .b)", [ab(1), ab(2)]);
-    gives(ab(1), ".a += (.a, .b)", [ab(2), ab(3)]);
     gives(ab(1), ".a |= (.+1, .)", [ab(2)]);
+    gives(ab(1), ".a += (.a, .b)", [ab(2), ab(3)]);
 }
 
 // here, jaq diverges from jq, which returns [3,6,4,8]!

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -8,9 +8,14 @@ use serde_json::json;
 #[test]
 fn update_assign() {
     let ab = |v| json!({"a": v, "b": 2});
-    gives(ab(1), ".a  = (.a, .b)", [ab(1), ab(2)]);
-    gives(ab(1), ".a |= (.+1, .)", [ab(2)]);
-    gives(ab(1), ".a += (.a, .b)", [ab(2), ab(3)]);
+    gives(ab(Some(1)), ".a  = (.a, .b)", [ab(Some(1)), ab(Some(2))]);
+    gives(ab(Some(1)), ".a |= (.+1, .)", [ab(Some(2))]);
+    gives(
+        ab(None),
+        ".a = .a+.b | ., .a = .a+.b",
+        [ab(Some(2)), ab(Some(4))],
+    );
+    gives(ab(Some(1)), ".a += (.a, .b)", [ab(Some(2)), ab(Some(3))]);
 }
 
 // here, jaq diverges from jq, which returns [3,6,4,8]!

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -15,6 +15,11 @@ fn update_assign() {
         ".a = .a+.b | ., .a = .a+.b",
         [ab(Some(2)), ab(Some(4))],
     );
+    gives(
+        ab(None),
+        ".a //= .a+.b | ., .a //= .a+.b",
+        [ab(Some(2)), ab(Some(2))],
+    );
     gives(ab(Some(1)), ".a += (.a, .b)", [ab(Some(2)), ab(Some(3))]);
 }
 

--- a/jaq-parse/src/filter.rs
+++ b/jaq-parse/src/filter.rs
@@ -162,6 +162,7 @@ fn binary_op() -> impl Parser<Token, BinaryOp, Error = Simple<Token>> + Clone {
         // therefore, we add `,` later
         assign(AssignOp::Assign),
         assign(AssignOp::Update),
+        assign(AssignOp::AltUpdate),
         update_with(MathOp::Add),
         update_with(MathOp::Sub),
         update_with(MathOp::Mul),

--- a/jaq-parse/src/token.rs
+++ b/jaq-parse/src/token.rs
@@ -215,7 +215,10 @@ pub fn tree(
 
 pub fn token() -> impl Parser<char, Token, Error = Simple<char>> {
     // A parser for operators
-    let op = one_of("|=!<>+-*/%").chain(one_of("=/").or_not()).collect();
+    let op = one_of("|=!<>+-*/%")
+        .chain::<char, _, _>(just('/').or_not())
+        .chain::<char, _, _>(just('=').or_not())
+        .collect();
 
     let var = just('$').ignore_then(text::ident());
 

--- a/jaq-syn/Cargo.toml
+++ b/jaq-syn/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 description = "Syntax of the jaq language"
 repository = "https://github.com/01mf02/jaq"
 keywords = ["json", "query", "jq"]
+rust-version = "1.63"
 
 [features]
 default = ["serde"]

--- a/jaq-syn/src/filter.rs
+++ b/jaq-syn/src/filter.rs
@@ -5,7 +5,7 @@ use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Assignment operators (`=`, `|=`, `+=`, …)
+/// Assignment operators (`=`, `|=`, `//=`, `+=`, …)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub enum AssignOp {
@@ -13,6 +13,8 @@ pub enum AssignOp {
     Assign,
     /// Update-assignment operator (`|=`)
     Update,
+    /// Alternation update-assignment operator (`//=`)
+    AltUpdate,
     /// Arithmetic update-assignment operator (`+=`, `-=`, `*=`, `/=`, `%=`, …)
     UpdateWith(MathOp),
 }
@@ -22,6 +24,7 @@ impl fmt::Display for AssignOp {
         match self {
             Self::Assign => "=".fmt(f),
             Self::Update => "|=".fmt(f),
+            Self::AltUpdate => "//=".fmt(f),
             Self::UpdateWith(op) => write!(f, "{op}="),
         }
     }

--- a/jaq-syn/src/ops.rs
+++ b/jaq-syn/src/ops.rs
@@ -3,24 +3,24 @@ use core::ops::{Add, Div, Mul, Rem, Sub};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Arithmetic operation, such as `+`, `-`, `*`, `/`, `%`.
+/// Binary arithmetical operators (`+`, `-`, `*`, `/`, `%`, …)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MathOp {
-    /// Addition
+    /// Addition operator (`+`)
     Add,
-    /// Subtraction
+    /// Subtraction operator (`-`)
     Sub,
-    /// Multiplication
+    /// Multiplication operator (`*`)
     Mul,
-    /// Division
+    /// Division operator (`/`)
     Div,
-    /// Remainder
+    /// Remainder operator (`%`)
     Rem,
 }
 
 impl MathOp {
-    /// Perform the arithmetic operation on the given inputs.
+    /// Perform the arithmetical operation on the given inputs.
     pub fn run<I, O>(&self, l: I, r: I) -> O
     where
         I: Add<Output = O> + Sub<Output = O> + Mul<Output = O> + Div<Output = O> + Rem<Output = O>,
@@ -47,26 +47,26 @@ impl fmt::Display for MathOp {
     }
 }
 
-/// An operation that orders two values, such as `<`, `<=`, `>`, `>=`, `==`, `!=`.
+/// Binary comparative operators (`<`, `<=`, `>`, `>=`, `==`, `!=`, …)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum OrdOp {
-    /// Less-than (<).
+    /// Less-than operation (`<`).
     Lt,
-    /// Less-than or equal (<=).
+    /// Less-than or equal-to operation (`<=`).
     Le,
-    /// Greater-than (>).
+    /// Greater-than operation (`>`).
     Gt,
-    /// Greater-than or equal (>=).
+    /// Greater-than or equal-to operation (`>=`).
     Ge,
-    /// Equals (=).
+    /// Equal-to operation (`=`).
     Eq,
-    /// Not equals (!=).
+    /// Not equal-to operation (`!=`).
     Ne,
 }
 
 impl OrdOp {
-    /// Perform the ordering operation on the given inputs.
+    /// Perform the comparative operation on the given inputs.
     pub fn run<I: PartialOrd + PartialEq>(&self, l: &I, r: &I) -> bool {
         match self {
             Self::Gt => l > r,


### PR DESCRIPTION
> [!NOTE]  
> This PR is a patch stack. Do not squash these commits.

Implement the alternation update-assignment operator (called the "alternate update-assignment operator") by jq.

Additionally, increase documentation coverage & make some documentation more consistent.

The name `AltUpdate` is chosen in anticipation of renaming `UpdateWith` & `UpdateMath` to `MathUpdate`. If `AssignOp::UpdateWith` should be kept, I believe it should become `UpdateWith(BinaryOp)`, and `Ast::UpdateMath` should then also both be renamed to `Ast::UpdateWith` and become `UpdateWith(Id, BinaryOp, Id)`.