### PR TITLE
Extend path syntax

### DIFF
--- a/jaq-interpret/tests/path.rs
+++ b/jaq-interpret/tests/path.rs
@@ -41,6 +41,8 @@ fn index_access() {
 #[test]
 fn iter_access() {
     gives(json!([0, 1, 2]), ".[]", [json!(0), json!(1), json!(2)]);
+    gives(json!({"a": [1, 2]}), ".a[]", [json!(1), json!(2)]);
+    gives(json!({"a": [1, 2]}), ".a.[]", [json!(1), json!(2)]);
     gives(json!({"a": 1, "b": 2}), ".[]", [json!(1), json!(2)]);
     // TODO: correct this
     //gives(json!({"b": 2, "a": 1}), ".[]", [json!(2), json!(1)]);

--- a/jaq-parse/src/filter.rs
+++ b/jaq-parse/src/filter.rs
@@ -208,9 +208,8 @@ pub fn filter() -> impl Parser<Token, Spanned<Filter>, Error = Simple<Token>> + 
 
     // e.g. `.[].a` or `.a`
     let id = just(Token::Dot).map_with_span(|_, span| (Filter::Id, span));
-    let index = super::path::index(with_comma.clone());
-    let index_path = index.or_not().chain(atom_path());
-    let id_with_path = id.then(index_path.collect());
+    let id_path = super::path::part(with_comma.clone()).chain(atom_path());
+    let id_with_path = id.then(id_path.or_not().flatten());
 
     let path = atom_with_path.or(id_with_path);
 

--- a/jaq-parse/src/path.rs
+++ b/jaq-parse/src/path.rs
@@ -22,14 +22,32 @@ where
     .labelled("object key")
 }
 
-pub fn index<T, P>(expr: P) -> impl Parser<Token, (Part<Spanned<T>>, Opt), Error = P::Error> + Clone
+fn index<T, P>(expr: P) -> impl Parser<Token, Part<Spanned<T>>, Error = P::Error> + Clone
 where
     T: From<Str<Spanned<T>>> + From<Call<Spanned<T>>>,
     P: Parser<Token, Spanned<T>, Error = Simple<Token>> + Clone,
 {
-    key(expr)
-        .map_with_span(|id, span| Part::Index((T::from(id), span)))
-        .then(opt())
+    key(expr).map_with_span(|id, span| Part::Index((T::from(id), span)))
+}
+
+/// Match `[]`, `[e]`, `[e:]`, `[e:e]`, `[:e]` (all without brackets).
+fn range<T, P>(expr: P) -> impl Parser<Token, Part<Spanned<T>>, Error = P::Error> + Clone
+where
+    P: Parser<Token, Spanned<T>, Error = Simple<Token>> + Clone,
+{
+    let e2 = just(Token::Colon).ignore_then(expr.clone().or_not());
+    let starts_with_expr = expr.clone().then(e2.or_not()).map(|(e1, e2)| match e2 {
+        None => Part::Index(e1),
+        Some(e2) => Part::Range(Some(e1), e2),
+    });
+    let starts_with_colon = just(Token::Colon)
+        .ignore_then(expr.clone())
+        .map(|e2| Part::Range(None, Some(e2)));
+
+    starts_with_expr
+        .or(starts_with_colon)
+        .or_not()
+        .map(|o| o.unwrap_or(Part::Range(None, None)))
 }
 
 pub fn path<T, P>(expr: P) -> impl Parser<Token, Path<T>, Error = P::Error> + Clone
@@ -37,28 +55,17 @@ where
     T: From<Str<Spanned<T>>> + From<Call<Spanned<T>>>,
     P: Parser<Token, Spanned<T>, Error = Simple<Token>> + Clone,
 {
-    let range = {
-        let e2 = just(Token::Colon).ignore_then(expr.clone().or_not());
-        let starts_with_expr = expr.clone().then(e2.or_not()).map(|(e1, e2)| match e2 {
-            None => Part::Index(e1),
-            Some(e2) => Part::Range(Some(e1), e2),
-        });
-        let starts_with_colon = just(Token::Colon)
-            .ignore_then(expr.clone())
-            .map(|e2| Part::Range(None, Some(e2)));
+    let range = Delim::Brack.around(range(expr.clone()));
+    let dot_index = just(Token::Dot).ignore_then(index(expr));
+    let dot_range = just(Token::Dot).or_not().ignore_then(range);
+    dot_index.or(dot_range).then(opt()).repeated()
+}
 
-        starts_with_expr
-            .or(starts_with_colon)
-            .or_not()
-            .map(|o| o.unwrap_or(Part::Range(None, None)))
-    };
-
-    let ranges = Delim::Brack.around(range).then(opt()).repeated();
-
-    let dot_id = just(Token::Dot).ignore_then(index(expr));
-
-    ranges
-        .clone()
-        .chain(dot_id.chain(ranges).repeated().flatten())
-        .collect()
+pub fn part<T, P>(expr: P) -> impl Parser<Token, (Part<Spanned<T>>, Opt), Error = P::Error> + Clone
+where
+    T: From<Str<Spanned<T>>> + From<Call<Spanned<T>>>,
+    P: Parser<Token, Spanned<T>, Error = Simple<Token>> + Clone,
+{
+    let range = Delim::Brack.around(range(expr.clone()));
+    range.or(index(expr)).then(opt())
 }


### PR DESCRIPTION
This PR extends the syntax in jaq to also allow for `.a.[]` forms.

In jq 1.7, a query `.a.[]` is valid syntax, whereas in jq 1.6, this is invalid syntax. (However, `.a[]` is valid in both.)
This was encountered in #134. @kklingenberg attempted a fix in #138; however, I took the opportunity to make my own PR and completely redo the path parsing, as it got rather messy. I just borrowed the tests from @kklingenberg's PR.