### PR TITLE
Correct `Default` implementation for `Owned` filters.

### DIFF
--- a/jaq-interpret/src/filter.rs
+++ b/jaq-interpret/src/filter.rs
@@ -8,8 +8,14 @@ use jaq_syn::filter::FoldType;
 use jaq_syn::{MathOp, OrdOp};
 
 /// Function from a value to a stream of value results.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Owned(Id, Vec<Ast>);
+
+impl Default for Owned {
+    fn default() -> Self {
+        Self(Id(0), Vec::from([Ast::Id]))
+    }
+}
 
 #[derive(Debug, Copy, Clone)]
 pub struct Ref<'a>(Id, &'a [Ast]);


### PR DESCRIPTION
The automatically derived `Default` implementation for `Owned` was incorrect, because it pointed to a non-existing filter AST. This made jaq crash when using `Owned::default`, as happened when not providing any filter at all (running `jaq` without any arguments).

Closes #146.