### PR TITLE
Implement indices, index and rindex.

### DIFF
--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -117,6 +117,28 @@ def any: any(.[]; .);
 def in(xs)    : . as $x | xs | has     ($x);
 def inside(xs): . as $x | xs | contains($x);
 
+# Indexing
+def indices($i):
+  def enumerate:
+    . as $thing |
+    if type == "string"
+    then range(length) | [., $thing[.:.+1]]
+    else range(length) | [., $thing[.]]
+    end;
+
+  def windowed($size):
+    if $size <= 0 then empty
+    else . as $array | range(length - $size + 1) | $array[.:. + $size]
+    end;
+
+  if ($i | type) == "array" or (type == "string" and ($i | type) == "string")
+  then [[windowed($i | length)] | enumerate | select(.[1] == $i)[0]]
+  else [enumerate | select(.[1] == $i)[0]]
+  end;
+
+def index($i):  indices($i) | .[0];
+def rindex($i): indices($i) | .[-1:][0];
+
 # Walking
 def walk(f): def rec: (.[]? |= rec) | f; rec;
 

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -105,6 +105,26 @@ yields!(flatten_obj, "{a: 1} | flatten", json!([{"a": 1}]));
 yields!(flatten_num, "0 | flatten", [0]);
 
 #[test]
+fn indices() {
+    give(
+        json!("a,b, cd, efg, hijk"),
+        r#"indices(", ")"#,
+        json!([3, 7, 12]),
+    );
+    give(json!([0, 1, 2, 1, 3, 1, 4]), "indices(1)", json!([1, 3, 5]));
+    give(
+        json!([0, 1, 2, 3, 1, 4, 2, 5, 1, 2, 6, 7]),
+        "indices([1, 2])",
+        json!([1, 8]),
+    );
+    give(json!([]), "indices([])", json!([]));
+    give(json!([1, 2]), "indices([1, 2, 3])", json!([]));
+    give(json!(["a", "b", "c"]), r#"indices("b")"#, json!([1]));
+    give(json!([0, 0, 0]), "indices([0, 0])", json!([0, 1]));
+    give(json!("aaa"), r#"indices("aa")"#, json!([0, 1]));
+}
+
+#[test]
 fn inside() {
     give(
         json!(["foo", "bar"]),


### PR DESCRIPTION
This PR implements `indices` and copies jq's derivative implementations of `index` and `rindex` according to the spec [here](https://jqlang.github.io/jq/manual/#indices). Note that jq has TODO's related to performance on said implementations, so perhaps you'd want to close this PR and wait for a performant version of these filters.

~Also, the behaviour of jq's `indices` varies slightly when dealing with strings. I reported/asked about it here: <https://github.com/jqlang/jq/issues/3030>~ (my mistake; jq solved the issue in 1.7)

Closes #154