### PR TITLE
String splitting via division.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bincode"

--- a/jaq-core/Cargo.toml
+++ b/jaq-core/Cargo.toml
@@ -25,7 +25,7 @@ regex = { version = "1.9", optional = true }
 log = { version = "0.4.17", optional = true }
 libm = { version = "0.2.7", optional = true }
 aho-corasick = { version = "1.0", optional = true }
-base64 = { version = "0.21.2", optional = true }
+base64 = { version = "0.22", optional = true }
 urlencoding = { version = "2.1.3", optional = true }
 
 [dev-dependencies]

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -167,18 +167,6 @@ fn as_codepoint(v: &Val) -> Result<char, Error> {
     char::from_u32(u).ok_or_else(|| Error::str(format_args!("cannot use {u} as character")))
 }
 
-/// Split a string by a given separator string.
-fn split(s: &str, sep: &str) -> Vec<Val> {
-    if sep.is_empty() {
-        // Rust's `split` function with an empty separator ("")
-        // yields an empty string as first and last result
-        // to prevent this, we are using `chars` instead
-        s.chars().map(|s| Val::str(s.to_string())).collect()
-    } else {
-        s.split(sep).map(|s| Val::str(s.to_string())).collect()
-    }
-}
-
 /// This implements a ~10x faster version of:
 /// ~~~ text
 /// def range($from; $to; $by): $from |
@@ -339,10 +327,6 @@ const CORE_RUN: &[(&str, usize, RunPtr)] = &[
         let to_int = |i: usize| Val::Int(i.try_into().unwrap());
         let f = move |v| indices(&cv.1, &v?).map(|idxs| Val::arr(idxs.map(to_int).collect()));
         Box::new(vals.map(f))
-    }),
-    ("split", 1, |args, cv| {
-        let seps = args.get(0).run(cv.clone());
-        Box::new(seps.map(move |sep| Ok(Val::arr(split(cv.1.as_str()?, sep?.as_str()?)))))
     }),
     ("first", 1, |args, cv| Box::new(args.get(0).run(cv).take(1))),
     ("limit", 2, |args, cv| {

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -308,16 +308,6 @@ fn round() {
 }
 
 #[test]
-fn split() {
-    give(json!("aöß"), r#"split("")"#, json!(["a", "ö", "ß"]));
-    give(
-        json!("abcabcdab"),
-        r#"split("ab")"#,
-        json!(["", "c", "cd", ""]),
-    );
-}
-
-#[test]
 fn startswith() {
     give(json!("foobar"), r#"startswith("")"#, json!(true));
     give(json!("foobar"), r#"startswith("bar")"#, json!(false));

--- a/jaq-interpret/src/val.rs
+++ b/jaq-interpret/src/val.rs
@@ -415,6 +415,20 @@ impl core::ops::Mul for Val {
     }
 }
 
+/// Split a string by a given separator string.
+fn split<'a>(s: &'a str, sep: &'a str) -> Box<dyn Iterator<Item = String> + 'a> {
+    if s.is_empty() {
+        Box::new(core::iter::empty())
+    } else if sep.is_empty() {
+        // Rust's `split` function with an empty separator ("")
+        // yields an empty string as first and last result
+        // to prevent this, we are using `chars` instead
+        Box::new(s.chars().map(|s| s.to_string()))
+    } else {
+        Box::new(s.split(sep).map(|s| s.to_string()))
+    }
+}
+
 impl core::ops::Div for Val {
     type Output = ValR;
     fn div(self, rhs: Self) -> Self::Output {
@@ -426,6 +440,7 @@ impl core::ops::Div for Val {
             (Float(x), Float(y)) => Ok(Float(x / y)),
             (Num(n), r) => Self::from_dec_str(&n) / r,
             (l, Num(n)) => l / Self::from_dec_str(&n),
+            (Str(x), Str(y)) => Ok(Val::arr(split(&x, &y).map(Val::str).collect())),
             (l, r) => Err(Error::MathOp(l, MathOp::Div, r)),
         }
     }

--- a/jaq-interpret/tests/tests.rs
+++ b/jaq-interpret/tests/tests.rs
@@ -63,6 +63,11 @@ fn mul() {
     );
 }
 
+yields!(div_str, r#""abcabcdab" / "ab""#, ["", "c", "cd", ""]);
+yields!(div_str_empty, r#""" / """#, json!([]));
+yields!(div_str_empty_str, r#""" / "ab""#, json!([]));
+yields!(div_str_empty_sep, r#""aöß" / """#, ["a", "ö", "ß"]);
+
 #[test]
 fn logic() {
     let tf = json!([true, false]);

--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -135,6 +135,9 @@ def    scan(re; flags): matches(re; flags)[] | .[0].string;
 def   match(re; flags): matches(re; flags)[] | .[0] + { captures: .[1:] };
 def capture(re; flags): matches(re; flags)[] | capture_of_match;
 
+def split($sep):
+  if isstring and ($sep | isstring) then . / $sep
+  else error("split input and separator must be strings") end;
 def split (re; flags): split_(re; flags + "g");
 def splits(re; flags): split(re; flags)[];
 

--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jaq"
 version = "1.3.0"
 authors = ["Michael Färber <michael.faerber@gedenkt.at>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 readme = "../README.md"
 description = "Just another JSON query tool"


### PR DESCRIPTION
This PR makes it possible to split a string `s` by `sep` via `s / sep`.
Previously, the same could be achieved by `s | split(sep)`.

Furthermore, the behaviour of `split` now matches jq, which returns `[]` when `s` is `""`. Before, `split` would return `[""]`.