### PR TITLE
Add Windows install (Scoop) instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ You may also install jaq using [homebrew](https://formulae.brew.sh/formula/jaq) 
     $ brew install jaq
     $ brew install --HEAD jaq # latest development version
 
+Or using [scoop](https://scoop.sh/#/apps?q=jaq&id=59dbaf2bb778402cd8ec50d0ad4cdae8a6814fc3) on Windows:
+
+    > scoop install main/jaq
 
 
 # Examples


### PR DESCRIPTION
Since I found this tool by looking for `jq` on [Scoop](https://scoop.sh/), I thought it could be nice to add install instructions on Windows.

Scoop is sort of like Homebrew for Windows. The manifest auto-updates to the latest release from this repository.
You can find the manifest for it [here](https://github.com/ScoopInstaller/Main/blob/master/bucket/jaq.json).