### PR TITLE
builtin semver 2.0.0 support

### DIFF
--- a/jaq-std/src/std.jq
+++ b/jaq-std/src/std.jq
@@ -161,3 +161,13 @@ def input: first(inputs);
 # Date
 def   todate:   todateiso8601;
 def fromdate: fromdateiso8601;
+
+# Semver
+def parse_semver: capture("^v?(?P<major>0|[1-9]\\d*)\\.(?P<minor>0|[1-9]\\d*)\\.(?P<patch>0|[1-9]\\d*)(?:-(?P<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$");
+def semver_ord:
+  parse_semver
+  | [ ( [.major, .minor, .patch] | map(tonumber) ),
+    if .prerelease == null then {} else
+       ( .prerelease | capture("^(?:(?<d>.*[^\\d\\n\\.])\\.?)?(?<v>\\d+)?$") | [ if .d == null then {} else .d end, if .v == null then {} else .v | tonumber end ] )
+    end
+  ];


### PR DESCRIPTION
This PR adds builtin support for parsing and ordering semver strings:

### `parse_semver` function: 
parses semver strings according to [semver regex](https://regex101.com/r/Ly7O1x/3/)

Taking the example valid semver strings this would look something like this:

`cat /tmp/test.json | jaq `
```json
[
  "0.0.4",
  "1.2.3",
  "10.20.30",
  "1.1.2-prerelease+meta",
  "1.1.2+meta",
  "1.1.2+meta-valid",
  "1.0.0-alpha",
  "1.0.0-beta",
  "1.0.0-alpha.beta",
  "1.0.0-alpha.beta.1",
  "1.0.0-alpha.1",
  "1.0.0-alpha0.valid",
  "1.0.0-alpha.0valid",
  "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",
  "1.0.0-rc.1+build.1",
  "2.0.0-rc.1+build.123",
  "1.2.3-beta",
  "10.2.3-DEV-SNAPSHOT",
  "1.2.3-SNAPSHOT-123",
  "1.0.0",
  "2.0.0",
  "1.1.7",
  "2.0.0+build.1848",
  "2.0.1-alpha.1227",
  "1.0.0-alpha+beta",
  "1.2.3----RC-SNAPSHOT.12.9.1--.12+788",
  "1.2.3----R-S.12.9.1--.12+meta",
  "1.2.3----RC-SNAPSHOT.12.9.1--.12",
  "1.0.0+0.build.1-rc.10000aaa-kk-0.1",
  "99999999999999999999999.999999999999999999.99999999999999999",
  "1.0.0-0A.is.legal",
  "3.0.0-rc.1",
  "3.0.0-rc.2",
  "3.0.0-rc.3",
  "3.0.0"
]
```
`cat /tmp/test.json | jaq 'map(. | parse_semver)' | [.[14]]`
```json
[
  {
    "major": "1",
    "minor": "0",
    "patch": "0",
    "prerelease": "rc.1",
    "buildmetadata": "build.1"
  }
]
```

### `semver_ord` function: 
use parse_semver to create a nested array sortable by `sort_by` function, this is done
by transforming the version into the following structure:

```
[ [.major, .minor, .patch], [ .prerelease_name, .prerelease_version_numbe] ]
```
- if there is no prerelease then the instead of the second array there will be `{}`.
- buildmetadata is ignored for ordering
- to construct the second array another regex is used which can be found [here](https://regex101.com/r/nhc7qr/1). It is what i came up with, if you think it should be adjusted feel free to play with it ;)
- the effect of this is that versions get orderd by their `[major, minor,  patch]` first. `prereleases` are ordered lexicographically first and then according to their subversion

applying the ordering to the above list of semver strings would look like this:

`cat /tmp/test.json | ./target/debug/jaq 'sort_by(. | semver_ord) | reverse'`
```json
[
  "99999999999999999999999.999999999999999999.99999999999999999",
  "10.20.30",
  "10.2.3-DEV-SNAPSHOT",
  "3.0.0",
  "3.0.0-rc.3",
  "3.0.0-rc.2",
  "3.0.0-rc.1",
  "2.0.1-alpha.1227",
  "2.0.0+build.1848",
  "2.0.0",
  "2.0.0-rc.1+build.123",
  "1.2.3",
  "1.2.3-beta",
  "1.2.3-SNAPSHOT-123",
  "1.2.3----RC-SNAPSHOT.12.9.1--.12",
  "1.2.3----RC-SNAPSHOT.12.9.1--.12+788",
  "1.2.3----R-S.12.9.1--.12+meta",
  "1.1.7",
  "1.1.2+meta-valid",
  "1.1.2+meta",
  "1.1.2-prerelease+meta",
  "1.0.0+0.build.1-rc.10000aaa-kk-0.1",
  "1.0.0",
  "1.0.0-rc.1+build.1",
  "1.0.0-beta",
  "1.0.0-alpha0.valid",
  "1.0.0-alpha.beta",
  "1.0.0-alpha.beta.1",
  "1.0.0-alpha.0valid",
  "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",
  "1.0.0-alpha+beta",
  "1.0.0-alpha",
  "1.0.0-alpha.1",
  "1.0.0-0A.is.legal",
  "0.0.4"
]
```