### PR TITLE
chore(core): export core functions based on enabled features

### DIFF
--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -53,6 +53,27 @@ pub fn core() -> impl Iterator<Item = (String, usize, Native)> {
         .chain(run(TIME))
 }
 
+/// Feature enabled filters.
+pub fn feature_enabled() -> impl Iterator<Item = (String, usize, Native)> {
+    let mut feature = minimal();
+    #[cfg(feature = "std")]
+    feature = feature.chain(run(STD));
+    #[cfg(feature = "format")]
+    feature = feature.chain(run(FORMAT));
+    #[cfg(feature = "log")]
+    feature = feature.chain(upd(LOG));
+    #[cfg(feature = "math")]
+    feature = feature.chain(run(MATH));
+    #[cfg(feature = "parse_json")]
+    feature = feature.chain(run(PARSE_JSON));
+    #[cfg(feature = "regex")]
+    feature = feature.chain(run(REGEX));
+    #[cfg(feature = "time")]
+    feature = feature.chain(run(TIME));
+
+    feature
+}
+
 fn run<'a>(fs: &'a [(&str, usize, RunPtr)]) -> impl Iterator<Item = (String, usize, Native)> + 'a {
     fs.iter()
         .map(|&(name, arity, f)| (name.to_string(), arity, Native::new(f)))


### PR DESCRIPTION
The main idea behind this PR is that some applications are platform independent and they do not need std.

currently we have option for `jaq_core::core()` and `jaq_core::minimal()` but core needs all features to be enabled, there is no way that we can avoid excluding specific feature. 

This pr adds new function `feature_enabled` which chains with feature flags 