### PR TITLE
Update ahash 0.8.6 -> 0.8.11 for stdsimd feature and Color::Unset -> Color::Primary to reflect yansi v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,12 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "ariadne"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd002a6223f12c7a95cdd4b1cb3a0149d22d37f7a9ecdb2cb691a071fe236c29"
+checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
 dependencies = [
  "unicode-width",
- "yansi",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ dependencies = [
  "atty",
  "serde",
  "serde_json",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -767,6 +767,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/jaq-interpret/Cargo.toml
+++ b/jaq-interpret/Cargo.toml
@@ -17,7 +17,7 @@ std = []
 
 [dependencies]
 jaq-syn = { version = "1.1.0", path = "../jaq-syn" }
-ahash = "0.8.6"
+ahash = "0.8.11"
 dyn-clone = "1.0"
 hifijson = { version = "0.2.0", optional = true }
 indexmap = "2.0"

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -300,7 +300,7 @@ fn report<'a>(e: chumsky::error::Simple<String>) -> ariadne::Report<'a> {
     use ariadne::{Color, Fmt, Label, Report, ReportKind};
     use chumsky::error::SimpleReason;
 
-    let (red, yellow) = (Color::Unset, Color::Unset);
+    let (red, yellow) = (Color::Primary, Color::Primary);
     let config = ariadne::Config::default().with_color(false);
 
     let msg = if let SimpleReason::Custom(msg) = e.reason() {

--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -20,7 +20,7 @@ jaq-parse     = { version = "1.0.0", path = "../jaq-parse" }
 jaq-interpret = { version = "1.2.0", path = "../jaq-interpret" }
 jaq-core      = { version = "1.2.0", path = "../jaq-core" }
 jaq-std       = { version = "1.2.0", path = "../jaq-std" }
-ariadne = "0.4.0"
+ariadne = "0.4.1"
 atty = "0.2"
 chumsky = { version = "0.9.0", default-features = false }
 clap = { version = "4.0.0", features = ["derive"] }

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -495,7 +495,7 @@ fn report<'a>(e: chumsky::error::Simple<String>) -> ariadne::Report<'a> {
     let (red, yellow) = if isatty {
         (Color::Red, Color::Yellow)
     } else {
-        (Color::Unset, Color::Unset)
+        (Color::Primary, Color::Primary)
     };
     let config = ariadne::Config::default().with_color(isatty);
 


### PR DESCRIPTION
Closes https://github.com/01mf02/jaq/issues/178 and https://github.com/01mf02/jaq/issues/176.