### PR TITLE
Replace ariadne with codesnake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,16 +31,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
-name = "ariadne"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd002a6223f12c7a95cdd4b1cb3a0149d22d37f7a9ecdb2cb691a071fe236c29"
-dependencies = [
- "unicode-width",
- "yansi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "codesnake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdbcda08384319005fd4b79b08aa04728dbafa702d304d737b5ccbd556df331"
+
+[[package]]
 name = "colored_json"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,7 +141,7 @@ dependencies = [
  "atty",
  "serde",
  "serde_json",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -262,10 +258,10 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 name = "jaq"
 version = "1.4.0"
 dependencies = [
- "ariadne",
  "atty",
  "chumsky",
  "clap",
+ "codesnake",
  "colored_json",
  "env_logger",
  "hifijson",
@@ -278,6 +274,8 @@ dependencies = [
  "mimalloc",
  "serde_json",
  "tempfile",
+ "unicode-width",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -324,8 +322,8 @@ name = "jaq-play"
 version = "0.1.0"
 dependencies = [
  "aho-corasick",
- "ariadne",
  "chumsky",
+ "codesnake",
  "console_log",
  "getrandom",
  "hifijson",
@@ -336,6 +334,7 @@ dependencies = [
  "jaq-syn",
  "js-sys",
  "log",
+ "unicode-width",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -645,9 +644,9 @@ checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "urlencoding"
@@ -767,6 +766,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/jaq-play/Cargo.toml
+++ b/jaq-play/Cargo.toml
@@ -21,14 +21,15 @@ jaq-parse     = { version = "1.0.0", path = "../jaq-parse" }
 jaq-interpret = { version = "1.2.0", path = "../jaq-interpret" }
 jaq-core      = { version = "1.2.0", path = "../jaq-core" }
 jaq-std       = { version = "1.2.0", path = "../jaq-std" }
-ariadne = "0.4.0"
+aho-corasick = "1.1.2"
+codesnake = { version = "0.1" }
 chumsky = { version = "0.9.0", default-features = false }
 hifijson = "0.2"
 log = "0.4.17"
+unicode-width = "0.1.13"
 
 console_log = { version = "1.0", features = ["color"] }
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = ["DedicatedWorkerGlobalScope"] }
 js-sys = { version = "0.3" }
-aho-corasick = "1.1.2"

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -193,16 +193,14 @@ pub fn run(filter: &str, input: &str, settings: &JsValue, scope: &Scope) {
         Ok(()) => (),
         Err(Error::Chumsky(errs)) => {
             for e in errs {
-                let mut buf = Vec::new();
-                let cache = ariadne::Source::from(filter);
-                report(e).write(cache, &mut buf).unwrap();
-                let s = String::from_utf8(buf).unwrap();
-                scope.post_message(&format!("⚠️ Parse {s}").into()).unwrap();
+                scope
+                    .post_message(&format!("⚠️ Parse error: {}", report(&filter, &e)).into())
+                    .unwrap();
             }
         }
         Err(Error::Hifijson(e)) => {
             scope
-                .post_message(&format!("⚠️ Parse Error: {e}").into())
+                .post_message(&format!("⚠️ Parse error: {e}").into())
                 .unwrap();
         }
         Err(Error::Jaq(e)) => {
@@ -296,14 +294,33 @@ fn parse(filter_str: &str, vars: Vec<String>) -> Result<Filter, Vec<ChumskyError
     }
 }
 
-fn report<'a>(e: chumsky::error::Simple<String>) -> ariadne::Report<'a> {
-    use ariadne::{Color, Fmt, Label, Report, ReportKind};
+#[derive(Debug)]
+struct Report<'a> {
+    code: &'a str,
+    message: String,
+    labels: Vec<(core::ops::Range<usize>, String, Color)>,
+}
+
+#[derive(Clone, Debug)]
+enum Color {
+    Yellow,
+    Red,
+}
+
+impl Color {
+    fn apply(&self, d: impl Display) -> String {
+        let mut color = format!("{self:?}");
+        color.make_ascii_lowercase();
+        format!("<span class={color}>{d}</span>",)
+    }
+}
+
+fn report<'a>(code: &'a str, e: &chumsky::error::Simple<String>) -> Report<'a> {
     use chumsky::error::SimpleReason;
 
-    let (red, yellow) = (Color::Unset, Color::Unset);
-    let config = ariadne::Config::default().with_color(false);
+    let eof = || "end of input".to_string();
 
-    let msg = if let SimpleReason::Custom(msg) = e.reason() {
+    let message = if let SimpleReason::Custom(msg) = e.reason() {
         msg.clone()
     } else {
         let found = if e.found().is_some() {
@@ -319,13 +336,8 @@ fn report<'a>(e: chumsky::error::Simple<String>) -> ariadne::Report<'a> {
         let expected = if e.expected().len() == 0 {
             "something else".to_string()
         } else {
-            e.expected()
-                .map(|expected| match expected {
-                    Some(expected) => expected.to_string(),
-                    None => "end of input".to_string(),
-                })
-                .collect::<Vec<_>>()
-                .join(", ")
+            let f = |e: &Option<String>| e.as_ref().map_or_else(eof, |e| e.to_string());
+            e.expected().map(f).collect::<Vec<_>>().join(", ")
         };
         format!("{found}{when}, expected {expected}",)
     };
@@ -333,27 +345,44 @@ fn report<'a>(e: chumsky::error::Simple<String>) -> ariadne::Report<'a> {
     let label = if let SimpleReason::Custom(msg) = e.reason() {
         msg.clone()
     } else {
-        format!(
-            "Unexpected {}",
-            e.found()
-                .map(|c| format!("token {}", c.fg(red)))
-                .unwrap_or_else(|| "end of input".to_string())
-        )
+        let token = |c: &String| format!("token {}", Color::Red.apply(c));
+        format!("Unexpected {}", e.found().map_or_else(eof, token))
     };
-
-    let report = Report::build(ReportKind::Error, (), e.span().start)
-        .with_message(msg)
-        .with_label(Label::new(e.span()).with_message(label).with_color(red));
-
-    let report = match e.reason() {
-        SimpleReason::Unclosed { span, delimiter } => report.with_label(
-            Label::new(span.clone())
-                .with_message(format!("Unclosed delimiter {}", delimiter.fg(yellow)))
-                .with_color(yellow),
-        ),
-        SimpleReason::Unexpected => report,
-        SimpleReason::Custom(_) => report,
+    // convert character indices to byte offsets
+    let char_to_byte = |i| {
+        code.char_indices()
+            .map(|(i, _c)| i)
+            .chain([code.len(), code.len()])
+            .nth(i)
+            .unwrap()
     };
+    let conv = |span: &core::ops::Range<_>| char_to_byte(span.start)..char_to_byte(span.end);
+    let mut labels = Vec::from([(conv(&e.span()), label, Color::Red)]);
 
-    report.with_config(config).finish()
+    if let SimpleReason::Unclosed { span, delimiter } = e.reason() {
+        let text = format!("Unclosed delimiter {}", Color::Yellow.apply(delimiter));
+        labels.insert(0, (conv(span), text, Color::Yellow));
+    }
+    Report {
+        code,
+        message,
+        labels,
+    }
+}
+
+impl Display for Report<'_> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        use codesnake::{Block, CodeWidth, Label, LineIndex};
+        let idx = LineIndex::new(self.code);
+        let labels = self.labels.clone().into_iter().map(|(range, text, color)| {
+            Label::new(range, text).with_style(move |s| color.apply(s).to_string())
+        });
+        let block = Block::new(&idx, labels).unwrap().map_code(|c| {
+            let c = c.replace('\t', "    ");
+            let w = unicode_width::UnicodeWidthStr::width(&*c);
+            CodeWidth::new(c, core::cmp::max(w, 1))
+        });
+        writeln!(f, "{}", self.message)?;
+        write!(f, "{}\n{}{}", block.prologue(), block, block.epilogue())
+    }
 }

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -194,7 +194,7 @@ pub fn run(filter: &str, input: &str, settings: &JsValue, scope: &Scope) {
         Err(Error::Chumsky(errs)) => {
             for e in errs {
                 scope
-                    .post_message(&format!("⚠️ Parse error: {}", report(&filter, &e)).into())
+                    .post_message(&format!("⚠️ Parse error: {}", report(filter, &e)).into())
                     .unwrap();
             }
         }

--- a/jaq-play/src/style.css
+++ b/jaq-play/src/style.css
@@ -104,6 +104,9 @@ textarea {
 .null    { color: magenta; }
 .key     { color: red; }
 
+.red     { color: #dc322f; }
+.yellow  { color: #b58900; }
+
 
 .settings { display: inline-block; }
 

--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -20,9 +20,9 @@ jaq-parse     = { version = "1.0.0", path = "../jaq-parse" }
 jaq-interpret = { version = "1.2.0", path = "../jaq-interpret" }
 jaq-core      = { version = "1.2.0", path = "../jaq-core" }
 jaq-std       = { version = "1.2.0", path = "../jaq-std" }
-ariadne = "0.4.0"
 atty = "0.2"
 chumsky = { version = "0.9.0", default-features = false }
+codesnake = { version = "0.1" }
 clap = { version = "4.0.0", features = ["derive"] }
 colored_json = "3.0.1"
 env_logger = { version = "0.10.0", default-features = false }
@@ -31,3 +31,5 @@ memmap2 = "0.9"
 mimalloc = { version = "0.1.29", default-features = false, optional = true }
 serde_json = { version = "1.0.81", features = [ "arbitrary_precision", "preserve_order" ] }
 tempfile = "3.3.0"
+unicode-width = "0.1.13"
+yansi = "1.0.1"

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -144,7 +144,7 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
         return Ok(run_tests(std::fs::File::open(test_file)?));
     }
 
-    let (vars, ctx) = binds(&cli)?.into_iter().unzip();
+    let (vars, ctx) = binds(cli)?.into_iter().unzip();
 
     let mut args = cli.args.iter();
     let filter = match &cli.from_file {
@@ -161,14 +161,14 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
     let files: Vec<_> = args.collect();
 
     let last = if files.is_empty() {
-        let inputs = read_buffered(&cli, io::stdin().lock());
-        with_stdout(|out| run(&cli, &filter, ctx, inputs, |v| print(&cli, v, out)))?
+        let inputs = read_buffered(cli, io::stdin().lock());
+        with_stdout(|out| run(cli, &filter, ctx, inputs, |v| print(cli, v, out)))?
     } else {
         let mut last = None;
         for file in files {
             let path = std::path::Path::new(file);
             let file = load_file(path).map_err(|e| Error::Io(Some(file.to_string()), e))?;
-            let inputs = read_slice(&cli, &file);
+            let inputs = read_slice(cli, &file);
             if cli.in_place {
                 // create a temporary file where output is written to
                 let location = path.parent().unwrap();
@@ -176,8 +176,8 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
                     .prefix("jaq")
                     .tempfile_in(location)?;
 
-                last = run(&cli, &filter, ctx.clone(), inputs, |output| {
-                    print(&cli, output, tmp.as_file_mut())
+                last = run(cli, &filter, ctx.clone(), inputs, |output| {
+                    print(cli, output, tmp.as_file_mut())
                 })?;
 
                 // replace the input file with the temporary file
@@ -186,7 +186,7 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
                 std::fs::set_permissions(path, perms)?;
             } else {
                 last = with_stdout(|out| {
-                    run(&cli, &filter, ctx.clone(), inputs, |v| print(&cli, v, out))
+                    run(cli, &filter, ctx.clone(), inputs, |v| print(cli, v, out))
                 })?;
             }
         }

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -460,7 +460,7 @@ fn print(cli: &Cli, val: Val, writer: &mut impl Write) -> io::Result<()> {
         Val::Str(s) if cli.raw_output => write!(writer, "{s}")?,
         _ => {
             let val = serde_json::Value::from(val);
-            let color = cli.color.use_if(|| atty::is(Stdout) && !cli.in_place);
+            let color = !cli.in_place && cli.color.use_if(|| atty::is(Stdout));
             let mode = if color { ColorMode::On } else { ColorMode::Off };
             let indent = if cli.tab {
                 String::from("\t")

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -130,9 +130,9 @@ fn main() -> ExitCode {
         Ok(exit) => exit,
         Err(e) => {
             if cli.color.use_if(|| atty::is(atty::Stream::Stderr)) {
-                yansi::enable()
+                yansi::enable();
             } else {
-                yansi::disable()
+                yansi::disable();
             }
             e.report()
         }
@@ -594,8 +594,8 @@ fn run_test(test: jaq_syn::test::Test<String>) -> Result<(Val, Val), Error> {
 
     let filter = parse(&test.filter, Vec::new())?;
 
-    use hifijson::token::Lex;
     let json = |s: String| {
+        use hifijson::token::Lex;
         hifijson::SliceLexer::new(s.as_bytes())
             .exactly_one(Val::parse)
             .map_err(invalid_data)
@@ -607,7 +607,7 @@ fn run_test(test: jaq_syn::test::Test<String>) -> Result<(Val, Val), Error> {
 }
 
 fn run_tests(file: std::fs::File) -> ExitCode {
-    let lines = io::BufReader::new(file).lines().map(|l| l.unwrap());
+    let lines = io::BufReader::new(file).lines().map(Result::unwrap);
     let tests = jaq_syn::test::Parser::new(lines);
 
     let (mut passed, mut total) = (0, 0);


### PR DESCRIPTION
At the time of writing, the `ariadne` crate had [broken semantic versioning](https://github.com/zesterer/ariadne/issues/116) for over a month. This motivated my moving away from it to a newly-written crate called `codesnake`. Apart from having fewer dependencies and a significantly smaller code base, this crate enables colored parse error messages in jaq-play.

This should close https://github.com/01mf02/jaq/issues/176 as well as https://github.com/01mf02/jaq/issues/177.