### PR TITLE
Use `chrono` instead of `time`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +70,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "clap"
@@ -240,6 +255,7 @@ version = "1.5.0"
 dependencies = [
  "aho-corasick",
  "base64",
+ "chrono",
  "hifijson",
  "jaq-interpret",
  "jaq-syn",
@@ -247,7 +263,6 @@ dependencies = [
  "log",
  "regex",
  "serde_json",
- "time",
  "urlencoding",
 ]
 
@@ -360,6 +375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
 dependencies = [
  "libmimalloc-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -549,33 +573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "time"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
-dependencies = [
- "itoa",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
-name = "time-macros"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
-dependencies = [
- "time-core",
 ]
 
 [[package]]

--- a/jaq-core/Cargo.toml
+++ b/jaq-core/Cargo.toml
@@ -16,11 +16,12 @@ std = []
 format = ["aho-corasick", "base64", "urlencoding"]
 math = ["libm"]
 parse_json = ["hifijson"]
+time = ["chrono"]
 
 [dependencies]
 jaq-interpret = { version = "1.5.0", path = "../jaq-interpret" }
 hifijson = { version = "0.2.0", optional = true }
-time = { version = "0.3.20", optional = true, features = ["formatting", "parsing"] }
+chrono = { version = "0.4.38", default-features = false, features = ["alloc"], optional = true }
 regex = { version = "1.9", optional = true }
 log = { version = "0.4.17", optional = true }
 libm = { version = "0.2.7", optional = true }

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -37,25 +37,22 @@ fn ascii() {
     give(json!("aAaAäの"), "ascii_downcase", json!("aaaaäの"));
 }
 
-#[test]
-fn dateiso8601() {
-    give(
-        json!("1970-01-02T00:00:00Z"),
-        "fromdateiso8601",
-        json!(86400),
-    );
-    give(
-        json!("1970-01-02T00:00:00.123456789Z"),
-        "fromdateiso8601",
-        json!(86400.123456789),
-    );
-    give(json!(86400), "todateiso8601", json!("1970-01-02T00:00:00Z"));
-    give(
-        json!(86400.123456789),
-        "todateiso8601",
-        json!("1970-01-02T00:00:00.123456789Z"),
-    );
-}
+yields!(
+    fromdate,
+    r#""1970-01-02T00:00:00Z" | fromdateiso8601"#,
+    86400
+);
+yields!(
+    fromdate_micros,
+    r#""1970-01-02T00:00:00.123456Z" | fromdateiso8601"#,
+    86400.123456
+);
+yields!(todate, r#"86400 | todateiso8601"#, "1970-01-02T00:00:00Z");
+yields!(
+    todate_micros,
+    r#"86400.123456 | todateiso8601"#,
+    "1970-01-02T00:00:00.123456Z"
+);
 
 #[test]
 fn explode_implode() {

--- a/jaq-std/tests/std.rs
+++ b/jaq-std/tests/std.rs
@@ -25,34 +25,33 @@ fn any() {
     give(json!({"a": false, "b": true}), "any", json!(true));
 }
 
-#[test]
-fn date() {
-    // aliases for fromdateiso8601 and todateiso8601
-    give(json!("1970-01-02T00:00:00Z"), "fromdate", json!(86400));
-    give(
-        json!("1970-01-02T00:00:00.123456789Z"),
-        "fromdate",
-        json!(86400.123456789),
-    );
-    give(json!(86400), "todate", json!("1970-01-02T00:00:00Z"));
-    give(
-        json!(86400.123456789),
-        "todate",
-        json!("1970-01-02T00:00:00.123456789Z"),
-    );
-}
+// aliases for fromdateiso8601 and todateiso8601
+yields!(fromdate, r#""1970-01-02T00:00:00Z" | fromdate"#, 86400);
+yields!(
+    fromdate_mu,
+    r#""1970-01-02T00:00:00.123456Z" | fromdate"#,
+    86400.123456
+);
+yields!(todate, r#"86400 | todate"#, "1970-01-02T00:00:00Z");
+yields!(
+    todate_mu,
+    r#"86400.123456 | todate"#,
+    "1970-01-02T00:00:00.123456Z"
+);
+
+yields!(tofromdate, "946684800|todate|fromdate", 946684800);
+yields!(
+    tofromdate_mu,
+    "946684800.123456|todate|fromdate",
+    946684800.123456
+);
 
 #[test]
-fn date_roundtrip() {
-    let epoch = 946684800;
-    give(json!(epoch), "todate|fromdate", json!(epoch));
-    let epoch_ns = 946684800.123456;
-    give(json!(epoch_ns), "todate|fromdate", json!(epoch_ns));
-
+fn fromtodate() {
     let iso = "2000-01-01T00:00:00Z";
     give(json!(iso), "fromdate|todate", json!(iso));
-    let iso_ns = "2000-01-01T00:00:00.123456000Z";
-    give(json!(iso_ns), "fromdate|todate", json!(iso_ns));
+    let iso_mu = "2000-01-01T00:00:00.123456Z";
+    give(json!(iso_mu), "fromdate|todate", json!(iso_mu));
 }
 
 yields!(


### PR DESCRIPTION
The crate `time` does not build on Rust 1.80 for versions smaller than 0.3.36: https://github.com/time-rs/time/issues/681
Apart from the fact that I do not like packages stopping to build when *updating* the compiler, updating time to 0.3.36 would require raising MSRV to 1.67, which I do not like.

I found that the `chrono` crate has a lower MSRV, it works fine on all compiler versions I tried, and using it is considerably simpler for my use case, so this PR replaces `time` with `chrono`. 
A small side effect of this is that jaq outputs fractional seconds with 6 digits instead of 9 before.