### PR TITLE
Consider metadata during file loading 

### DIFF
--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -169,7 +169,7 @@ pub(crate) enum FoldType {
 pub type Error<S> = (S, Undefined);
 
 /// Compilation errors.
-pub type Errors<S> = Vec<(load::File<S>, Vec<Error<S>>)>;
+pub type Errors<S> = load::Errors<S, Vec<Error<S>>>;
 
 /// Type of an undefined symbol.
 #[derive(Debug)]
@@ -308,7 +308,7 @@ impl<'s, F> Compiler<&'s str, F> {
         self.imported_vars = mods
             .iter()
             .enumerate()
-            .flat_map(|(mid, (_file, m))| m.vars.iter().map(move |(_path, x)| (*x, mid)))
+            .flat_map(|(mid, (_file, m))| m.vars.iter().map(move |(_path, x, _meta)| (*x, mid)))
             .collect();
 
         let mut errs = Vec::new();

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -15,7 +15,10 @@
 //! use serde_json::{json, Value};
 //!
 //! let input = json!(["Hello", "world"]);
-//! let code = ".[]";
+//! let program = File {
+//!     path: "".into(),
+//!     code: ".[]",
+//! };
 //!
 //! use load::{Arena, File, Loader};
 //!
@@ -26,7 +29,7 @@
 //! let arena = Arena::default();
 //!
 //! // parse the filter
-//! let modules = loader.load(&arena, File { path: "", code }).unwrap();
+//! let modules = loader.load(&arena, program).unwrap();
 //!
 //! // compile the filter
 //! let filter = jaq_core::Compiler::<_, Native<_>>::default()

--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -229,7 +229,7 @@ fn std_read(
         if let Ok(code) = std::fs::read_to_string(&path) {
             use alloc::string::ToString;
             let path = path.display().to_string();
-            return Ok(File { code, path })
+            return Ok(File { code, path });
         }
     }
     Err("file not found".into())

--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -225,7 +225,8 @@ impl<'a> Import<'a, &'a str> {
         paths.into_iter().flatten().collect()
     }
 
-    fn find(self, paths: &[PathBuf], ext: &str) -> Result<PathBuf, String> {
+    /// Try to find a file with given extension in the given search paths.
+    pub fn find(self, paths: &[PathBuf], ext: &str) -> Result<PathBuf, String> {
         let parent = Path::new(self.parent).parent().unwrap_or(Path::new("."));
 
         let mut rel = Path::new(self.path).to_path_buf();

--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -38,7 +38,7 @@ pub struct Loader<S, R> {
     open: Vec<String>,
 }
 
-/// Path and contents of a (module) file, both represented by `S`.
+/// Contents `C` and path `P` of a (module) file.
 ///
 /// This is useful for creating precise error messages.
 #[derive(Clone, Debug, Default)]
@@ -55,7 +55,7 @@ pub struct Import<'a, S> {
     ///
     /// This is a String, not an `S`, because it usually does not appear in the source.
     pub parent: &'a String,
-    /// relative path of the imported/included module
+    /// relative path of the imported/included module, as given in the source
     pub path: &'a S,
     /// metadata attached to the import/include directive
     pub meta: &'a Option<Term<S>>,

--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -238,7 +238,7 @@ impl<'a> Import<'a, &'a str> {
         self.meta_paths()
             .iter()
             .chain(paths)
-            .map(|path| parent.join(path).join(&rel))
+            .filter_map(|path| parent.join(path).join(&rel).canonicalize().ok())
             .find(|path| path.is_file())
             .ok_or_else(|| "file not found".into())
     }

--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -238,7 +238,8 @@ impl<'a> Import<'a, &'a str> {
         self.meta_paths()
             .iter()
             .chain(paths)
-            .filter_map(|path| parent.join(path).join(&rel).canonicalize().ok())
+            .map(|path| parent.join(path).join(&rel))
+            .filter_map(|path| path.canonicalize().ok())
             .find(|path| path.is_file())
             .ok_or_else(|| "file not found".into())
     }

--- a/jaq-core/tests/common/mod.rs
+++ b/jaq-core/tests/common/mod.rs
@@ -7,7 +7,8 @@ fn yields(x: Val, code: &str, ys: impl Iterator<Item = ValR>) {
 
     let arena = Arena::default();
     let loader = Loader::new([]);
-    let modules = loader.load(&arena, File { path: "", code }).unwrap();
+    let path = "".into();
+    let modules = loader.load(&arena, File { path, code }).unwrap();
     let filter = Compiler::<_, Native<_>>::default()
         .compile(modules)
         .unwrap();

--- a/jaq-json/tests/common/mod.rs
+++ b/jaq-json/tests/common/mod.rs
@@ -6,7 +6,8 @@ fn yields(x: Val, code: &str, ys: impl Iterator<Item = ValR>) {
 
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
-    let modules = loader.load(&arena, File { path: "", code }).unwrap();
+    let path = "".into();
+    let modules = loader.load(&arena, File { path, code }).unwrap();
     let filter = jaq_core::Compiler::default()
         .with_funs(jaq_std::funs().chain(jaq_json::funs()))
         .compile(modules)

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -262,7 +262,8 @@ fn parse(path: &str, code: &str, vars: &[String]) -> Result<(Vec<Val>, Filter), 
 
     let vars: Vec<_> = vars.iter().map(|v| format!("${v}")).collect();
     let arena = Arena::default();
-    let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs())).with_std_read();
+    let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
+    let path = path.into();
     let modules = loader
         .load(&arena, File { path, code })
         .map_err(load_errors)?;
@@ -287,7 +288,7 @@ fn load_errors(errs: load::Errors<&str>) -> Vec<FileReports> {
             Error::Lex(errs) => errs.into_iter().map(|e| report_lex(code, e)).collect(),
             Error::Parse(errs) => errs.into_iter().map(|e| report_parse(code, e)).collect(),
         };
-        (file.map(|s| s.into()), err)
+        (file.map_code(|s| s.into()), err)
     });
     errs.collect()
 }
@@ -296,7 +297,7 @@ fn compile_errors(errs: compile::Errors<&str>) -> Vec<FileReports> {
     let errs = errs.into_iter().map(|(file, errs)| {
         let code = file.code;
         let errs = errs.into_iter().map(|e| report_compile(code, e)).collect();
-        (file.map(|s| s.into()), errs)
+        (file.map_code(|s| s.into()), errs)
     });
     errs.collect()
 }

--- a/jaq-std/tests/common/mod.rs
+++ b/jaq-std/tests/common/mod.rs
@@ -6,7 +6,8 @@ fn yields(x: Val, code: &str, ys: impl Iterator<Item = ValR>) {
 
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs());
-    let modules = loader.load(&arena, File { path: "", code }).unwrap();
+    let path = "".into();
+    let modules = loader.load(&arena, File { path, code }).unwrap();
     let filter = jaq_core::Compiler::default()
         .with_funs(jaq_std::funs())
         .compile(modules)

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -289,8 +289,8 @@ fn parse(
 
     let mut vals = Vec::new();
     import(&modules, |p| {
-        // TODO: consider search path here!
-        vals.push(json_array(p.path).map_err(|e| e.to_string())?);
+        let path = p.find(paths, "json")?;
+        vals.push(json_array(path).map_err(|e| e.to_string())?);
         Ok(())
     })
     .map_err(load_errors)?;


### PR DESCRIPTION
This PR implements the `-L` command-line option and considers metadata of the shape {..., search: s, ...} attached to import/include directives. This applies to both module and data loading.