### PR TITLE
Fix escaping of unicode characters in strings

### DIFF
--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -9,6 +9,9 @@ use core::fmt::{self, Debug};
 use jaq_core::{load, ops, path, Exn, Native, RunPtr};
 use jaq_std::{once_with, ow, run, unary, v, Filter};
 
+#[cfg(feature = "serde_json")]
+use serde_json;
+
 #[cfg(feature = "hifijson")]
 use hifijson::{LexAlloc, Token};
 
@@ -520,6 +523,14 @@ impl Val {
                 .iter()
                 .all(|(k, r)| l.get(k).map_or(false, |l| l.contains(r))),
             _ => self == other,
+        }
+    }
+
+    #[cfg(feature = "serde_json")]
+    pub fn to_escaped_string(&self) -> Result<serde_json::Value, Error> {
+        match self {
+            Self::Str(s) => Ok(serde_json::Value::String(s.to_string())),
+            _ => Err(Error::typ(self.clone(), Type::Str.as_str())),
         }
     }
 

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -560,7 +560,7 @@ fn fmt_val(f: &mut Formatter, opts: &PpOpts, level: usize, v: &Val) -> fmt::Resu
         Val::Float(x) if x.is_finite() => write!(f, "{x:?}"),
         Val::Float(_) => "null".fmt(f),
         Val::Num(n) => n.fmt(f),
-        Val::Str(s) => write!(f, "{:?}", s.green()),
+        Val::Str(_s) => write!(f, "{}", v.to_escaped_string().expect("Failed to escape string").green()),
         Val::Arr(a) => {
             '['.bold().fmt(f)?;
             if !a.is_empty() {


### PR DESCRIPTION
Attempting to fix #209

Previously jaq would output strings with unicode escaped with rust debug format like:

```
{
  "a": "\u{200b}foo \u{200e}bar"
}
```

This is invalid json. Instead those unicode characters should be output directly.

This commit uses serde_json to serialize strings instead which escapes them correctly for json.

Unfortunately this change makes the serde_json feature required, which might not be desired for this project.