### PR TITLE
Add `trim/0`, `ltrim/0` and `rtrim/0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Here is an overview that summarises:
 - [x] String <-> integers (`explode`, `implode`)
 - [x] String normalisation (`ascii_downcase`, `ascii_upcase`)
 - [x] String prefix/postfix (`startswith`, `endswith`, `ltrimstr`, `rtrimstr`)
+- [x] String whitespace trimming (`trim`, `ltrim`, `rtrim`)
 - [x] String splitting (`split("foo")`)
 - [x] Array filters (`reverse`, `sort`, `sort_by(-.)`, `group_by`, `min_by`, `max_by`)
 - [x] Stream consumers (`first`, `last`, `range`, `fold`)

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -388,6 +388,15 @@ fn base_run<V: ValT, F: FilterT<V = V>>() -> Box<[Filter<RunPtr<V, F>>]> {
                     .map_or_else(|| v.clone(), |s| V::from(s.to_owned())))
             })
         }),
+        ("trim", v(0), |_, cv| {
+            ow!(Ok(cv.1.try_as_str()?.trim().to_string().into()))
+        }),
+        ("ltrim", v(0), |_, cv| {
+            ow!(Ok(cv.1.try_as_str()?.trim_start().to_string().into()))
+        }),
+        ("rtrim", v(0), |_, cv| {
+            ow!(Ok(cv.1.try_as_str()?.trim_end().to_string().into()))
+        }),
         ("escape_csv", v(0), |_, cv| {
             ow!(Ok(cv.1.try_as_str()?.replace('"', "\"\"").into()))
         }),

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -230,3 +230,39 @@ fn rtrimstr() {
     give(json!("foobar"), r#"rtrimstr("foo")"#, json!("foobar"));
     give(json!("اَلْعَرَبِيَّةُ"), r#"rtrimstr("ا")"#, json!("اَلْعَرَبِيَّةُ"));
 }
+
+#[test]
+fn trim() {
+    give(json!(""), "trim", json!(""));
+    give(json!(" "), "trim", json!(""));
+    give(json!("  "), "trim", json!(""));
+    give(json!("foo"), "trim", json!("foo"));
+    give(json!(" foo  "), "trim", json!("foo"));
+    give(json!("  foo  "), "trim", json!("foo"));
+    give(json!("foo  "), "trim", json!("foo"));
+    give(json!(" اَلْعَرَبِيَّةُ "), "trim", json!("اَلْعَرَبِيَّةُ"));
+}
+
+#[test]
+fn ltrim() {
+    give(json!(""), "ltrim", json!(""));
+    give(json!(" "), "ltrim", json!(""));
+    give(json!("  "), "ltrim", json!(""));
+    give(json!("foo"), "ltrim", json!("foo"));
+    give(json!(" foo  "), "ltrim", json!("foo  "));
+    give(json!("  foo  "), "ltrim", json!("foo  "));
+    give(json!("foo  "), "ltrim", json!("foo  "));
+    give(json!(" اَلْعَرَبِيَّةُ "), "ltrim", json!("اَلْعَرَبِيَّةُ "));
+}
+
+#[test]
+fn rtrim() {
+    give(json!(""), "rtrim", json!(""));
+    give(json!(" "), "rtrim", json!(""));
+    give(json!("  "), "rtrim", json!(""));
+    give(json!("foo"), "rtrim", json!("foo"));
+    give(json!("  foo "), "rtrim", json!("  foo"));
+    give(json!("  foo  "), "rtrim", json!("  foo"));
+    give(json!("  foo"), "rtrim", json!("  foo"));
+    give(json!(" اَلْعَرَبِيَّةُ "), "rtrim", json!(" اَلْعَرَبِيَّةُ"));
+}


### PR DESCRIPTION
Trims leading and trailing whitespace.

Was added to jq in https://github.com/jqlang/jq/pull/3056