### PR TITLE
Patterns in variable bindings.

### DIFF
--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -159,6 +159,11 @@ impl<T> Default for Term<T> {
     }
 }
 
+pub(crate) enum Pattern<F> {
+    Var,
+    Idx(Vec<(F, Self)>),
+}
+
 /// Compilation error.
 pub type Error<S> = (S, Undefined);
 

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -393,11 +393,11 @@ impl<F: FilterT<F>> FilterT<F> for Id {
                 (cv.0.clone(), cv.1),
                 Box::new(move |v| r.update(lut, (cv.0.clone(), v), f.clone())),
             ),
-            Ast::Pipe(l, Some(pat), r) => {
-                reduce(run_and_bind(l, lut, cv.clone(), pat), cv.1, move |ctx, v| {
-                    r.update(lut, (ctx, v), f.clone())
-                })
-            }
+            Ast::Pipe(l, Some(pat), r) => reduce(
+                run_and_bind(l, lut, (cv.0, cv.1.clone()), pat),
+                cv.1,
+                move |ctx, v| r.update(lut, (ctx, v), f.clone()),
+            ),
             Ast::Comma(l, r) => {
                 let l = l.update(lut, (cv.0.clone(), cv.1), f.clone());
                 Box::new(

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -393,12 +393,11 @@ impl<F: FilterT<F>> FilterT<F> for Id {
                 (cv.0.clone(), cv.1),
                 Box::new(move |v| r.update(lut, (cv.0.clone(), v), f.clone())),
             ),
-            Ast::Pipe(l, Some(Pattern::Var), r) => {
-                reduce(l.run(lut, cv.clone()), cv.1, move |x, v| {
-                    r.update(lut, (cv.0.clone().cons_var(x), v), f.clone())
+            Ast::Pipe(l, Some(pat), r) => {
+                reduce(run_and_bind(l, lut, cv.clone(), pat), cv.1, move |ctx, v| {
+                    r.update(lut, (ctx, v), f.clone())
                 })
             }
-            Ast::Pipe(_, Some(Pattern::Idx(..)), _) => todo!(),
             Ast::Comma(l, r) => {
                 let l = l.update(lut, (cv.0.clone(), cv.1), f.clone());
                 Box::new(

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -284,7 +284,6 @@ impl<F: FilterT<F>> FilterT<F> for Id {
 
             Ast::Reduce(xs, pat, init, update) => {
                 let xs = rc_lazy_list::List::from_iter(run_and_bind(xs, lut, cv.clone(), pat));
-
                 let init = init.run(lut, cv.clone());
                 let update = |ctx, v| update.run(lut, (ctx, v));
                 Box::new(fold(false, xs, Fold::Output(init), update))

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -86,7 +86,7 @@ fn run_and_bind<'a, F: FilterT>(
     cv: Cv<'a, F::V>,
     pat: &'a Pattern<Id>,
 ) -> Results<'a, Ctx<'a, F::V>, Exn<'a, F::V>> {
-    let xs = xs.run(lut, cv.clone());
+    let xs = xs.run(lut, (cv.0.clone(), cv.1));
     match pat {
         Pattern::Var => map_with(xs, cv.0, move |y, ctx| Ok(ctx.cons_var(y?))),
         Pattern::Idx(pats) => flat_map_then_with(xs, cv.0, |y, ctx| {

--- a/jaq-core/src/fold.rs
+++ b/jaq-core/src/fold.rs
@@ -1,18 +1,7 @@
 //! Functions on iterators over results.
 
-use crate::box_iter::{box_once, BoxIter};
+use crate::box_iter::Results;
 use alloc::vec::Vec;
-
-/// A boxed iterator over `Result`s.
-pub type Results<'a, T, E> = BoxIter<'a, Result<T, E>>;
-
-/// If `x` is an `Err`, return it as iterator, else apply `f` to `x` and return its output.
-pub fn then<'a, T, U: 'a, E: 'a>(
-    x: Result<T, E>,
-    f: impl FnOnce(T) -> Results<'a, U, E>,
-) -> Results<'a, U, E> {
-    x.map_or_else(|e| box_once(Err(e)), f)
-}
 
 pub(crate) enum Fold<'a, U, E> {
     /// things to be processed

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -53,10 +53,11 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-mod box_iter;
+pub mod box_iter;
 pub mod compile;
 mod exn;
 mod filter;
+mod fold;
 mod into_iter;
 pub mod load;
 pub mod ops;
@@ -64,7 +65,6 @@ pub mod path;
 mod rc_iter;
 mod rc_lazy_list;
 mod rc_list;
-pub mod results;
 mod stack;
 pub mod val;
 

--- a/jaq-core/src/load/parse.rs
+++ b/jaq-core/src/load/parse.rs
@@ -206,6 +206,16 @@ impl<S> Term<S> {
     }
 }
 
+impl<S> Pattern<S> {
+    pub(crate) fn vars(&self) -> Box<dyn Iterator<Item = &S> + '_> {
+        match self {
+            Pattern::Var(x) => Box::new(core::iter::once(x)),
+            Pattern::Arr(a) => Box::new(a.iter().flat_map(|p| p.vars())),
+            Pattern::Obj(o) => Box::new(o.iter().flat_map(|(_k, p)| p.vars())),
+        }
+    }
+}
+
 impl<'s, 't> Parser<'s, 't> {
     /// Initialise a new parser on a sequence of [`Token`]s.
     #[must_use]

--- a/jaq-core/src/path.rs
+++ b/jaq-core/src/path.rs
@@ -1,7 +1,6 @@
 //! Paths and their parts.
 
-use crate::box_iter::{box_once, flat_map_with, map_with, BoxIter};
-use crate::results::then;
+use crate::box_iter::{box_once, flat_map_with, map_with, then, BoxIter};
 use crate::val::{ValR, ValT, ValX, ValXs};
 use alloc::{boxed::Box, vec::Vec};
 

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -28,7 +28,6 @@ pub type Range<V> = core::ops::Range<Option<V>>;
 pub trait ValT:
     Clone
     + Display
-    + Default
     + From<bool>
     + From<isize>
     + From<alloc::string::String>

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -418,6 +418,9 @@ yields!(pat_arr0, "[] as [$x] | $x", json!(null));
 yields!(pat_arr1, "[1, 2, 3] as [$x] | $x", 1);
 yields!(pat_arr2, "[1, 2, 3] as [$x, $y] | [$x, $y]", [1, 2]);
 
+yields!(pat_obj, "{a: 1, b: 2} as {a:  $x, $b } | [$x, $b]", [1, 2]);
+yields!(pat_nest, "{a: [1, 2]} as {a: [$x, $y]} | [$x, $y]", [1, 2]);
+
 const PAT_CART: &str = r#"{a: 1, b: 2, c: 3, d: 4} as {("a", "b"): $x, ("c", "d"): $y}"#;
 
 yields!(

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -407,3 +407,33 @@ yields!(limit10, &(LIMIT.to_owned() + "[limit(1; {}[])]"), json!([]));
 yields!(limit12, &(LIMIT.to_owned() + "[limit(1; 1, 2)]"), [1]);
 yields!(limit21, &(LIMIT.to_owned() + "[limit(2; 1)]"), [1]);
 yields!(limit22, &(LIMIT.to_owned() + "[limit(2; 1, 2)]"), [1, 2]);
+
+yields!(
+    pat_input,
+    r#"{a: {b: "c", c: 1}} as {a: {(.b): $x}} | $x"#,
+    1
+);
+
+yields!(pat_arr0, "[] as [$x] | $x", json!(null));
+yields!(pat_arr1, "[1, 2, 3] as [$x] | $x", 1);
+yields!(pat_arr2, "[1, 2, 3] as [$x, $y] | [$x, $y]", [1, 2]);
+
+const PAT_CART: &str = r#"{a: 1, b: 2, c: 3, d: 4} as {("a", "b"): $x, ("c", "d"): $y}"#;
+
+yields!(
+    pat_cart,
+    &format!("[{} | $x, $y]", PAT_CART),
+    [1, 3, 1, 4, 2, 3, 2, 4]
+);
+
+yields!(
+    reduce_pat_cart,
+    &format!("reduce {} ([]; . + [$x, $y])", PAT_CART),
+    [1, 3, 1, 4, 2, 3, 2, 4]
+);
+
+yields!(
+    update_pat_cart,
+    &format!("[0, 0, 0, 0, 0] | ({} | .[$x], .[$y]) += 1", PAT_CART),
+    [0, 2, 2, 2, 2]
+);

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -26,7 +26,7 @@ mod time;
 
 use alloc::string::{String, ToString};
 use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
-use jaq_core::results::then;
+use jaq_core::box_iter::then;
 use jaq_core::{load, Bind, Cv, Error, Exn, FilterT, Native, RunPtr, UpdatePtr, ValR, ValX, ValXs};
 
 /// Definitions of the standard library.


### PR DESCRIPTION
This PR adds support for patterns in variable bindings, e.g. `. as {a: [$x, {("b", "c"): $y, $z}]} | $x, $y, $z`.
This also works in `foreach` and `reduce`.

Compared to jq, this also allows indexing with integers, e.g. `{(0): $x, (1): $y}`, which is equivalent to `[$x, $y]`. This can be useful if you wish to destructure arrays, but not necessarily the starting items.

However, jaq does not support the (undocumented) syntax `{$x: ...}`; for example, the filter `{x: [1]} as {$x: [$y]} | $x, $y` this yields `[1]` and `1` in jq.