### PR TITLE
Fix floats not getting converted to ints after rounding + more strict equality in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -227,7 +227,8 @@ impl<F: FilterT> Filter<F> {
         impl <V: ValT> PartialEq for StrictEq<V> {
             fn eq(&self, other: &Self) -> bool {
                 match (&self.0, &other.0) {
-                    (Ok(a), Ok(b)) => a.strict_eq(b),
+                    // Sanity check: invoke both strict_eq and PartialEq
+                    (Ok(a), Ok(b)) => a == b && a.strict_eq(b),
                     (Err(a), Err(b)) => a == b,
                     _ => false,
                 }

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -119,4 +119,10 @@ pub trait ValT:
     /// `"\(v)"` yields `s`, otherwise it yields `v.to_string()`
     /// (provided by [`Display`]).
     fn as_str(&self) -> Option<&str>;
+
+    /// Compare against another value while enforcing strict equality.
+    /// We define strict equality as PartialEq with the following additional constraints:
+    /// - Both values must be of the same type.
+    /// - Fields in both values must be in the same order.
+    fn strict_eq(&self, other: &Self) -> bool;
 }

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -22,4 +22,4 @@ jaq-std  = { version = "2.0.0-beta", path = "../jaq-std" }
 ahash = "0.8.6"
 hifijson = { version = "0.2.0", optional = true }
 indexmap = "2.0"
-serde_json = { version = "1.0.81", optional = true }
+serde_json = { version = "1.0.81", features = ["preserve_order"], optional = true }

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -150,7 +150,7 @@ trait ValTx: ValT + Sized {
         if self.as_isize().is_some() {
             Ok(self)
         } else {
-            Ok(Self::from(f(self.as_f64()?)))
+            Ok(Self::from(f(self.as_f64()?) as isize))
         }
     }
 


### PR DESCRIPTION
Currently `jaq`'s handling of floats differs from the [behavior specified in the docs](https://github.com/01mf02/jaq?tab=readme-ov-file#numbers):
```
❯ jaq --version; jaq -n '1.2 | [floor, round, ceil]'
jaq 1.6.0
[
  1.0,
  1.0,
  2.0
]
```

`git bisect` shows that this started happening after this commit: https://github.com/01mf02/jaq/commit/dfc6fc0f352bd704f1e26a6f65d168cdc42de89d

This PR fixes the behavior so floats are converted to ints again after rounding:
```
❯ cargo run -- -n '1.2 | [floor, round, ceil]'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/jaq -n '1.2 | [floor, round, ceil]'`
[
  1,
  1,
  2
]
```

---

I've also tried to tighten up the equality check used during tests so it fails:
- If both values are of different types
- Or if the fields in both values are in a different order

This was a little complicated, and I'm not sure if this is even something you want, if it's worth the extra complexity or if the implementation is to your liking. Feedback is welcome, or you can also just close this PR and cherry-pick the float fix yourself if you don't want the test equality changes.