### PR TITLE
Allow empty regex matches unless using ignore empty flag

### DIFF
--- a/jaq-std/src/regex.rs
+++ b/jaq-std/src/regex.rs
@@ -93,7 +93,7 @@ impl<'a> ByteChar<'a> {
         assert!(self.prev_byte <= byte_offset);
         if self.prev_byte != byte_offset {
             self.prev_byte = byte_offset;
-            self.prev_char += 1 + self.rest.position(|(p, _)| p == byte_offset).unwrap();
+            self.prev_char += 1 + self.rest.position(|(p, _)| p == byte_offset).unwrap_or(0);
         }
         self.prev_char
     }
@@ -147,7 +147,7 @@ pub fn regex<'a>(s: &'a str, re: &'a Regex, flags: Flags, sm: (bool, bool)) -> V
 
     for c in re.captures_iter(s) {
         let whole = c.get(0).unwrap();
-        if whole.start() >= s.len() || (flags.ignore_empty() && whole.as_str().is_empty()) {
+        if whole.start() > s.len() || (flags.ignore_empty() && whole.as_str().is_empty()) {
             continue;
         }
         let match_names = c.iter().zip(re.capture_names());

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -179,6 +179,15 @@ fn regex() {
 
     give(json!(s), &f("matches", date, "g"), json!([d1, d2, d3]));
 
+    give(json!(""), &f("matches", "", ""), json!([[c(0, "")]]));
+    give(json!(""), &f("matches", "^$", ""), json!([[c(0, "")]]));
+    give(
+        json!("  "),
+        &f("matches", "", "g"),
+        json!([[c(0, "")], [c(1, "")], [c(2, "")]]),
+    );
+    give(json!("  "), &f("matches", "", "gn"), json!([]));
+
     let out = json!(["", d1, ", ", d2, " and ", d3, ""]);
     give(json!(s), &f("split_matches", date, "g"), out);
 


### PR DESCRIPTION
Fixes `"" | test("")` being false.