### PR TITLE
Add missing gamma/0 math function

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Zero-argument filters:
 - [x] `expm1`
 - [x] `fabs`
 - [x] `frexp`, which returns pairs of (float, integer).
+- [x] `gamma`
 - [x] `ilogb`, which returns integers.
 - [x] `j0`
 - [x] `j1`

--- a/jaq-std/src/defs.jq
+++ b/jaq-std/src/defs.jq
@@ -41,6 +41,7 @@ def pow10:            pow(10.0; .);
 def drem($l; r):      remainder($l; r) | if . == 0 then copysign(.; $l) end;
 def nexttoward(x; y): nextafter(x; y);
 def scalb(x; e):      x * pow(2.0; e);
+def gamma: tgamma;
 
 # Type
 def type:


### PR DESCRIPTION
```sh
$ cargo run -- -n '0,0.5,1,10 | gamma'
null
1.7724538509055159
1.0
362880.0

$ jq -n '0,0.5,1,10 | gamma'
1.7976931348623157e+308
1.772453850905516
1
362880

$ gojq -n '0,0.5,1,10 | gamma'
1.7976931348623157e+308
1.7724538509055159
1
362880
```