### PR TITLE
Correct tail recursion & improve compiler complexity

### DIFF
--- a/jaq-core/src/box_iter.rs
+++ b/jaq-core/src/box_iter.rs
@@ -63,7 +63,7 @@ pub fn flat_map_with<'a, T: Clone + 'a, U: 'a, V: 'a>(
     Box::new(l.flat_map(move |ly| r(ly, x.clone())))
 }
 
-/// Combination of [`flat_map`] and [`then`].
+/// Combination of [`Iterator::flat_map`] and [`then`].
 pub fn flat_map_then<'a, T: 'a, U: 'a, E: 'a>(
     l: impl Iterator<Item = Result<T, E>> + 'a,
     r: impl Fn(T) -> Results<'a, U, E> + 'a,

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -527,7 +527,7 @@ impl<'s, F> Compiler<&'s str, F> {
     ///
     /// Once we have processed all places where the sibling can be called from outside,
     /// we can then call `def_post`.
-    fn def_pre(&mut self, d: &parse::Def<&'s str, parse::Term<&'s str>>) {
+    fn def_pre(&mut self, d: &parse::Def<&'s str>) {
         let tid = self.lut.insert_term(Term::Id);
         let sig = Sig {
             name: d.name,
@@ -546,10 +546,7 @@ impl<'s, F> Compiler<&'s str, F> {
     }
 
     /// Compile a placeholder sibling with its corresponding definition.
-    fn def_post(
-        &mut self,
-        d: parse::Def<&'s str, parse::Term<&'s str>>,
-    ) -> (Sig<&'s str, Bind>, Def) {
+    fn def_post(&mut self, d: parse::Def<&'s str>) -> (Sig<&'s str, Bind>, Def) {
         let (def, tr) = self.locals.pop_sibling(d.name, d.args.len());
         let tid = def.id;
         let sig = Sig {

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -396,7 +396,8 @@ impl<'s, F> Compiler<&'s str, F> {
 
         m.body.iter().for_each(|def| self.def_pre(def));
         let defs = m.body.into_iter().rev().map(|def| self.def_post(def.body));
-        let defs = defs.collect();
+        let mut defs: Vec<_> = defs.collect();
+        defs.reverse();
         self.mod_map.push(defs)
     }
 

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -473,6 +473,9 @@ impl<'s, F> Compiler<&'s str, F> {
             }
         }
 
+        // uncomment the following line to disable tail-call optimisation (TCO)
+        //self.tailrecs.clear();
+
         // only after the end, we know which definitions are actually tail-recursive
         // before, we assumed that every call is tail-recursive
         // (that way, we can conveniently record whether a call to a function

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -565,7 +565,7 @@ impl<'s, F> Compiler<&'s str, F> {
         let tid = def.id;
         self.locals.push_parent(d.name, args, def);
         // at the beginning, we assume that any function can call itself tail-recursively
-        assert_eq!(tr.insert(tid), true);
+        assert!(tr.insert(tid));
         self.lut.terms[tid.0] = self.term(d.body, &tr);
         let def = self.locals.pop_parent(d.name, d.args.len());
         // only if there is at least one recursive call and all calls are tail-recursive,

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -360,6 +360,8 @@ impl<S: Copy + Ord> Locals<S> {
             }
         }
 
+        self.parents.insert(def.id);
+
         let entry = self.funs.entry((sig.name, sig.args.len())).or_default();
         entry.push((Fun::Parent(sig.args, def), vala))
     }
@@ -375,7 +377,7 @@ impl<S: Copy + Ord> Locals<S> {
                 Bind::Fun(f) => self.pop_arg(*f),
             }
         }
-        self.parents.remove(&def.id);
+        assert!(self.parents.remove(&def.id));
         (args, def)
     }
 

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -745,7 +745,7 @@ impl<'s, F> Compiler<&'s str, F> {
             .and_then(|v| v.last_mut())
         {
             Some((Fun::Arg, vala_)) => {
-                return std::dbg!(Term::Var(vala.0 - vala_.0, vala.1 - vala_.1));
+                return Term::Var(vala.0 - vala_.0, vala.1 - vala_.1);
             }
             Some((Fun::Sibling(args_, def, tr_), vala_)) => {
                 assert!(!tr.contains(&def.id));
@@ -863,7 +863,7 @@ impl<'s, F> Compiler<&'s str, F> {
 
     fn break_(&mut self, x: &'s str) -> Term {
         if let Some(l) = self.locals.labels.bound.get(x).and_then(|v| v.last()) {
-            return std::dbg!(Term::Break(self.locals.labels.total - l));
+            return Term::Break(self.locals.labels.total - l);
         }
         self.fail(x, Undefined::Label)
     }

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -610,13 +610,12 @@ impl<'s, F> Compiler<&'s str, F> {
             Num(n) => n.parse().map_or_else(|_| Term::Num(n.into()), Term::Int),
             // map `try f catch g` to `label $x | try f catch (g, break $x)`
             // and `try f` or `f?` to `label $x | try f catch (   break $x)`
-            TryCatch(t, c) => {
-                let break_ = Break("");
-                let catch = match c {
-                    None => break_,
-                    Some(c) => BinOp(c, parse::BinaryOp::Comma, break_.into()),
+            TryCatch(try_, catch) => {
+                let catch = match catch {
+                    None => Break(""),
+                    Some(c) => BinOp(c, parse::BinaryOp::Comma, Break("").into()),
                 };
-                let tc = self.with_label("", |c| Term::TryCatch(c.iterm(*t), c.iterm(catch)));
+                let tc = self.with_label("", |c| Term::TryCatch(c.iterm(*try_), c.iterm(catch)));
                 Term::Label(self.lut.insert_term(tc))
             }
             Fold(name, xs, pat, args) => {

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -321,11 +321,18 @@ impl<'s, F> Compiler<&'s str, F> {
             }
         }
 
+        /*
+        for (i, t) in self.lut.terms.iter().enumerate() {
+            std::println!("{i} -> {t:?}");
+        }
+        */
+
         if errs.is_empty() {
             // the main filter corresponds to the last definition of the last module
             let (main_sig, main_def) = self.mod_map.last().unwrap().last().unwrap();
             assert!(main_sig.matches("main", &[]));
             assert!(!main_def.tailrec);
+            //std::println!("main: {:?}", main_def.id);
             Ok(Filter(main_def.id, self.lut.map_funs(|(_sig, f)| f)))
         } else {
             Err(errs)

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -305,10 +305,10 @@ enum Fun<S> {
 
 #[derive(Default)]
 struct Locals<S> {
-    labels: MapVecLen<S>,
-    vars: MapVecLen<S>,
     // usize = number of vars
     funs: MapVec<(S, Arity), (Fun<S>, usize)>,
+    vars: MapVecLen<S>,
+    labels: MapVecLen<S>,
     parents: Tr,
 }
 

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -198,6 +198,8 @@ impl Undefined {
 }
 
 /// jq program compiler.
+///
+/// This contains strings of type `S` and native functions of type `F`.
 pub struct Compiler<S, F> {
     lut: Lut<(Sig<S>, F)>,
 

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -276,13 +276,14 @@ impl Def {
     }
 }
 
+/// Store a map of vectors plus the sum of the lengths of all vectors.
 #[derive(Default)]
-struct Bla<S> {
+struct MapVecLen<S> {
     bound: BTreeMap<S, Vec<usize>>,
     total: usize,
 }
 
-impl<S: Ord> Bla<S> {
+impl<S: Ord> MapVecLen<S> {
     fn push(&mut self, name: S) {
         self.total += 1;
         self.bound.entry(name).or_default().push(self.total);
@@ -304,8 +305,8 @@ enum Fun<S> {
 
 #[derive(Default)]
 struct Locals<S> {
-    labels: Bla<S>,
-    vars: Bla<S>,
+    labels: MapVecLen<S>,
+    vars: MapVecLen<S>,
     // usize = number of vars
     funs: BTreeMap<(S, Arity), Vec<(Fun<S>, usize)>>,
     parents: Tr,

--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -261,7 +261,7 @@ impl<S: Eq, A> Sig<S, A> {
     }
 }
 
-impl<S> Sig<S, Bind> {
+impl<S, A> Sig<S, Bind<A>> {
     fn bind(&self, args: &[TermId]) -> Box<[Bind<TermId>]> {
         let args = self.args.iter().zip(args);
         args.map(|(bind, id)| bind.as_ref().map(|_| *id)).collect()

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -122,13 +122,6 @@ impl<T> Bind<T, T> {
             Self::Fun(x) => Bind::Fun(f(x)),
         }
     }
-
-    pub(crate) fn name(&self) -> &T {
-        match self {
-            Self::Var(x) => x,
-            Self::Fun(x) => x,
-        }
-    }
 }
 
 impl<'a, V> Vars<'a, V> {

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -122,6 +122,13 @@ impl<T> Bind<T, T> {
             Self::Fun(x) => Bind::Fun(f(x)),
         }
     }
+
+    pub(crate) fn name(&self) -> &T {
+        match self {
+            Self::Var(x) => x,
+            Self::Fun(x) => x,
+        }
+    }
 }
 
 impl<'a, V> Vars<'a, V> {

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -446,3 +446,12 @@ yields!(
     &format!("[0, 0, 0, 0, 0] | ({} | .[$x], .[$y]) += 1", PAT_CART),
     [0, 2, 2, 2, 2]
 );
+
+// to see that `f` is not tail-recursive, we have to realise that:
+// 1. we cannot call ancestors of `g` tail-recursively (because we call `g + g`), and
+// 2. because `g` calls `f`, `f` cannot be tail-recursive
+yields!(
+    jqjq_tailrec,
+    "def f: if . then . else def g: f; 2 | g + g end; f",
+    4
+);

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -455,3 +455,5 @@ yields!(
     "def f: if . then . else def g: f; 2 | g + g end; f",
     4
 );
+
+yields!(tailrec, "def f: if . > 0 then .-1 | f end; 100000 | f", 0);

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -286,6 +286,7 @@ fn parse(
     let vars: Vec<_> = vars.iter().map(|v| format!("${v}")).collect();
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs())).with_std_read(paths);
+    //let loader = Loader::new([]).with_std_read(paths);
     let path = path.into();
     let modules = loader
         .load(&arena, File { path, code })

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -286,7 +286,7 @@ fn parse(
     let vars: Vec<_> = vars.iter().map(|v| format!("${v}")).collect();
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs())).with_std_read(paths);
-    let loader = Loader::new([]).with_std_read(paths);
+    //let loader = Loader::new([]).with_std_read(paths);
     let path = path.into();
     let modules = loader
         .load(&arena, File { path, code })

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -286,7 +286,7 @@ fn parse(
     let vars: Vec<_> = vars.iter().map(|v| format!("${v}")).collect();
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs())).with_std_read(paths);
-    //let loader = Loader::new([]).with_std_read(paths);
+    let loader = Loader::new([]).with_std_read(paths);
     let path = path.into();
     let modules = loader
         .load(&arena, File { path, code })

--- a/jaq/tests/a.jq
+++ b/jaq/tests/a.jq
@@ -2,4 +2,6 @@ include "b" {search: "."};
 import "c" as c {search: "mods"};
 import "data" as $data {search: "."};
 def a: b + c::c;
+def d: 2;
+def d: 3;
 def data: $data;

--- a/jaq/tests/golden.rs
+++ b/jaq/tests/golden.rs
@@ -92,7 +92,7 @@ test!(
 
 test!(
     mods,
-    &["-c", "-L", "tests", r#"include "a"; [a, data]"#],
+    &["-c", "-L", "tests", r#"include "a"; [a, data, d]"#],
     "0",
-    r#"["bcddd",[1,2]]"#
+    r#"["bcddd",[1,2],3]"#
 );


### PR DESCRIPTION
In #216, @wader found an expression `t` that would not yield the same result as `t | .`.
This boiled down to a bug in tail-call optimisation (TCO).

This PR corrects this bug. At the same time, it makes compilation more efficient, in particular when there are many definitions, variables, or labels. For example:

~~~
$ (echo 'def a: 1;'; for i in `seq 100000`; do echo 'def b: a;'; done; echo b) > bla.jq
$ jaq -n -f bla.jq
1
~~~

Previously, this would have taken quadratic time (with increasing values of `seq ...`); now, this takes n * log n time.
On the downside, the startup time becomes slightly longer for very small programs.

~~~
$ ./bench.sh target/release/jaq-tco-*
{"name": "empty", "n": 512, "time": {"target/release/jaq-tco-bug": [0.28], "target/release/jaq-tco-fix": [0.32]}}
{"name": "bf-fib", "n": 13, "time": {"target/release/jaq-tco-bug": [0.51], "target/release/jaq-tco-fix": [0.52]}}
{"name": "defs", "n": 100000, "time": {"target/release/jaq-tco-bug": [0.04], "target/release/jaq-tco-fix": [0.05]}}
{"name": "reduce-update", "n": 16384, "time": {"target/release/jaq-tco-bug": [0.01, 0.01, 0.01], "target/release/jaq-tco-fix": [0.01, 0.01, 0.01]}}
{"name": "reverse", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.09, 0.08, 0.07], "target/release/jaq-tco-fix": [0.08, 0.08, 0.08]}}
{"name": "sort", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.16, 0.16, 0.16], "target/release/jaq-tco-fix": [0.16, 0.16, 0.15]}}
{"name": "group-by", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.55, 0.55, 0.53], "target/release/jaq-tco-fix": [0.54, 0.54, 0.54]}}
{"name": "min-max", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.25, 0.25, 0.25], "target/release/jaq-tco-fix": [0.25, 0.25, 0.26]}}
{"name": "add", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.55, 0.52, 0.54], "target/release/jaq-tco-fix": [0.53, 0.54, 0.53]}}
{"name": "kv", "n": 131072, "time": {"target/release/jaq-tco-bug": [0.13, 0.13, 0.14], "target/release/jaq-tco-fix": [0.14, 0.14, 0.14]}}
{"name": "kv-update", "n": 131072, "time": {"target/release/jaq-tco-bug": [0.15, 0.15, 0.15], "target/release/jaq-tco-fix": [0.15, 0.15, 0.14]}}
{"name": "kv-entries", "n": 131072, "time": {"target/release/jaq-tco-bug": [0.62, 0.61, 0.61], "target/release/jaq-tco-fix": [0.61, 0.60, 0.61]}}
{"name": "ex-implode", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.56, 0.56, 0.56], "target/release/jaq-tco-fix": [0.56, 0.53, 0.54]}}
{"name": "reduce", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.82, 0.80, 0.83], "target/release/jaq-tco-fix": [0.81, 0.81, 0.81]}}
{"name": "try-catch", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.35, 0.35, 0.36], "target/release/jaq-tco-fix": [0.35, 0.36, 0.36]}}
{"name": "tree-contains", "n": 23, "time": {"target/release/jaq-tco-bug": [0.07, 0.07, 0.07], "target/release/jaq-tco-fix": [0.07, 0.07, 0.07]}}
{"name": "tree-flatten", "n": 17, "time": {"target/release/jaq-tco-bug": [0.89, 0.89, 0.90], "target/release/jaq-tco-fix": [0.89, 0.88, 0.86]}}
{"name": "tree-update", "n": 17, "time": {"target/release/jaq-tco-bug": [0.72, 0.72, 0.71], "target/release/jaq-tco-fix": [0.72, 0.72, 0.72]}}
{"name": "tree-paths", "n": 17, "time": {"target/release/jaq-tco-bug": [0.46, 0.47, 0.45], "target/release/jaq-tco-fix": [0.47, 0.46, 0.47]}}
{"name": "to-fromjson", "n": 65536, "time": {"target/release/jaq-tco-bug": [0.04, 0.04, 0.04], "target/release/jaq-tco-fix": [0.04, 0.04, 0.04]}}
{"name": "ack", "n": 7, "time": {"target/release/jaq-tco-bug": [0.53, 0.53, 0.53], "target/release/jaq-tco-fix": [0.49, 0.49, 0.50]}}
{"name": "range-prop", "n": 128, "time": {"target/release/jaq-tco-bug": [0.38, 0.38, 0.38], "target/release/jaq-tco-fix": [0.38, 0.39, 0.39]}}
{"name": "cumsum", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.31, 0.33, 0.32], "target/release/jaq-tco-fix": [0.33, 0.34, 0.32]}}
{"name": "cumsum-xy", "n": 1048576, "time": {"target/release/jaq-tco-bug": [0.54, 0.54, 0.53], "target/release/jaq-tco-fix": [0.55, 0.54, 0.53]}}
~~~

Here, we can see slightly worse values for `empty`, but improvements for `ack`.