### PR TITLE
Make `flat_map_then` strict.

### DIFF
--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -359,7 +359,7 @@ const ACKERMANN: &str = "def ack($m; $n):
   else ack($m-1; ack($m; $n-1))
   end;";
 
-yields!(ackermann, &(ACKERMANN.to_owned() + "ack(3; 4)"), 125);
+yields!(ackermann, &(ACKERMANN.to_owned() + "ack(3; 3)"), 61);
 
 #[test]
 fn reduce() {

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -121,6 +121,8 @@ fn limit() {
     give(json!(null), "[limit(-1; 0, 1)]", json!([]));
 }
 
+yields!(limit_overflow, "[limit(0; def f: f | .; f)]", json!([]));
+
 yields!(
     math_0_argument_scalar_filters,
     "[-2.2, -1.1, 0, 1.1, 2.2 | sin as $s | cos as $c | $s * $s + $c * $c]",


### PR DESCRIPTION
This is an optimisation that allows the estimation of the number of outputs of calls to functions (both definitions and natively implemented ones).

It has quite positive results on many commonly used functions, see the benchmark results.
Here, `jaq-fmt-lazy` is before this PR and `jaq-fmt-strict` is after this PR:

~~~
{"name": "empty", "n": 512, "time": {"./jaq-fmt-lazy": [0.34], "./jaq-fmt-strict": [0.37]}}
{"name": "bf-fib", "n": 13, "time": {"./jaq-fmt-lazy": [0.51], "./jaq-fmt-strict": [0.49]}}
{"name": "defs", "n": 100000, "time": {"./jaq-fmt-lazy": [0.05], "./jaq-fmt-strict": [0.05]}}
{"name": "reduce-update", "n": 16384, "time": {"./jaq-fmt-lazy": [0.01, 0.01, 0.01], "./jaq-fmt-strict": [0.01, 0.01, 0.01]}}
{"name": "reverse", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.09, 0.08, 0.08], "./jaq-fmt-strict": [0.04, 0.04, 0.04]}}
{"name": "sort", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.16, 0.16, 0.16], "./jaq-fmt-strict": [0.11, 0.11, 0.12]}}
{"name": "group-by", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.55, 0.55, 0.54], "./jaq-fmt-strict": [0.53, 0.52, 0.51]}}
{"name": "min-max", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.26, 0.26, 0.26], "./jaq-fmt-strict": [0.22, 0.21, 0.22]}}
{"name": "add", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.53, 0.52, 0.53], "./jaq-fmt-strict": [0.48, 0.48, 0.49]}}
{"name": "kv", "n": 131072, "time": {"./jaq-fmt-lazy": [0.13, 0.13, 0.13], "./jaq-fmt-strict": [0.12, 0.12, 0.12]}}
{"name": "kv-update", "n": 131072, "time": {"./jaq-fmt-lazy": [0.14, 0.15, 0.15], "./jaq-fmt-strict": [0.14, 0.13, 0.13]}}
{"name": "kv-entries", "n": 131072, "time": {"./jaq-fmt-lazy": [0.60, 0.60, 0.60], "./jaq-fmt-strict": [0.59, 0.59, 0.58]}}
{"name": "ex-implode", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.53, 0.55, 0.54], "./jaq-fmt-strict": [0.53, 0.51, 0.51]}}
{"name": "reduce", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.81, 0.82, 0.81], "./jaq-fmt-strict": [0.75, 0.77, 0.77]}}
{"name": "try-catch", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.36, 0.35, 0.36], "./jaq-fmt-strict": [0.29, 0.30, 0.29]}}
{"name": "tree-contains", "n": 23, "time": {"./jaq-fmt-lazy": [0.07, 0.07, 0.07], "./jaq-fmt-strict": [0.07, 0.07, 0.07]}}
{"name": "tree-flatten", "n": 17, "time": {"./jaq-fmt-lazy": [0.89, 0.87, 0.87], "./jaq-fmt-strict": [0.80, 0.80, 0.79]}}
{"name": "tree-update", "n": 17, "time": {"./jaq-fmt-lazy": [0.70, 0.71, 0.71], "./jaq-fmt-strict": [0.71, 0.70, 0.70]}}
{"name": "tree-paths", "n": 17, "time": {"./jaq-fmt-lazy": [0.46, 0.46, 0.47], "./jaq-fmt-strict": [0.45, 0.45, 0.45]}}
{"name": "to-fromjson", "n": 65536, "time": {"./jaq-fmt-lazy": [0.04, 0.04, 0.04], "./jaq-fmt-strict": [0.04, 0.04, 0.04]}}
{"name": "ack", "n": 7, "time": {"./jaq-fmt-lazy": [0.48, 0.49, 0.47], "./jaq-fmt-strict": [0.63, 0.64, 0.64]}}
{"name": "range-prop", "n": 128, "time": {"./jaq-fmt-lazy": [0.39, 0.39, 0.39], "./jaq-fmt-strict": [0.37, 0.37, 0.36]}}
{"name": "cumsum", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.33, 0.34, 0.32], "./jaq-fmt-strict": [0.28, 0.27, 0.28]}}
{"name": "cumsum-xy", "n": 1048576, "time": {"./jaq-fmt-lazy": [0.53, 0.54, 0.53], "./jaq-fmt-strict": [0.49, 0.49, 0.49]}}
~~~

Unfortunately, this optimisation seems to make jaq use more stack in some cases, such as the Ackermann function (`ack`). For that reason, we adapt the Ackermann test to calculate a smaller result, otherwise the test causes a stack overflow.