### PR TITLE
Interpret search paths via -L as relative to working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,12 +623,6 @@ The interpretation of `reduce`/`foreach` in jaq has the following advantages ove
   in jq, `join(x)` converts all elements of the input array to strings and intersperses them with `x`, whereas
   in jaq, `join(x)` simply calculates `x0 + x + x1 + x + ... + xn`.
   When all elements of the input array and `x` are strings, jq and jaq yield the same output.
-* Modules:
-  If the `-L` command-line option is not given, the search path for modules and data files
-  in jq is `["~/.jq", "$ORIGIN/../lib/jq", "$ORIGIN/../lib"]`, whereas
-  in jaq, it is `[]`.
-  However, this can be emulated in jaq by setting an alias such as
-  `alias jaq="jaq -L ~ -L \`which jaq\`/../lib/jq -L \`which jaq\`/../lib"`.
 
 
 

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -298,6 +298,12 @@ fn parse(
     use compile::Compiler;
     use load::{import, Arena, File, Loader};
 
+    let paths = if paths.is_empty() {
+        &["~/.jq", "$ORIGIN/../lib/jq", "$ORIGIN/../lib"].map(|x| x.into())
+    } else {
+        paths
+    };
+
     let vars: Vec<_> = vars.iter().map(|v| format!("${v}")).collect();
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs())).with_std_read(paths);


### PR DESCRIPTION
As a bonus, jaq now also uses the default search paths `["~/.jq", "$ORIGIN/../lib/jq", "$ORIGIN/../lib"]`.