### PR TITLE
Enable jaq to deal with non-UTF-8 file paths (on the command-line).

### DIFF
--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -162,7 +162,7 @@ pub(crate) enum Pattern<F> {
 pub type Error<S> = (S, Undefined);
 
 /// Compilation errors.
-pub type Errors<S> = load::Errors<S, Vec<Error<S>>>;
+pub type Errors<S, P> = load::Errors<S, P, Vec<Error<S>>>;
 
 /// Type of an undefined symbol.
 #[derive(Debug)]
@@ -478,7 +478,10 @@ impl<'s, F> Compiler<&'s str, F> {
     }
 
     /// Compile the given modules.
-    pub fn compile(mut self, mods: load::Modules<&'s str>) -> Result<Filter<F>, Errors<&'s str>> {
+    pub fn compile<P>(
+        mut self,
+        mods: load::Modules<&'s str, P>,
+    ) -> Result<Filter<F>, Errors<&'s str, P>> {
         self.imported_vars = mods
             .iter()
             .enumerate()

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -15,10 +15,7 @@
 //! use serde_json::{json, Value};
 //!
 //! let input = json!(["Hello", "world"]);
-//! let program = File {
-//!     path: "".into(),
-//!     code: ".[]",
-//! };
+//! let program = File { code: ".[]", path: () };
 //!
 //! use load::{Arena, File, Loader};
 //!

--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -26,22 +26,22 @@ extern crate std;
 pub struct Arena(typed_arena::Arena<String>);
 
 /// Combined file loader, lexer, and parser for multiple modules.
-pub struct Loader<S, R> {
+pub struct Loader<S, P, R> {
     #[allow(clippy::type_complexity)]
-    mods: Vec<(File<S, String>, Result<Module<S>, Error<S>>)>,
+    mods: Vec<(File<S, P>, Result<Module<S>, Error<S>>)>,
     /// function to read module file contents from a path
     read: R,
     /// currently processed modules
     ///
     /// This is used to detect circular dependencies between modules.
-    open: Vec<String>,
+    open: Vec<P>,
 }
 
 /// Contents `C` and path `P` of a (module) file.
 ///
 /// This is useful for creating precise error messages.
 #[derive(Clone, Debug, Default)]
-pub struct File<C, P = C> {
+pub struct File<C, P> {
     /// contents of the file
     pub code: C,
     /// path of the file
@@ -49,11 +49,11 @@ pub struct File<C, P = C> {
 }
 
 /// Information to resolve module/data imports.
-pub struct Import<'a, S> {
+pub struct Import<'a, S, P> {
     /// absolute path of the module where the import/include directive appears
     ///
-    /// This is a String, not an `S`, because it usually does not appear in the source.
-    pub parent: &'a String,
+    /// This is a path `P`, not a string `S`, because it usually does not appear in the source.
+    pub parent: &'a P,
     /// relative path of the imported/included module, as given in the source
     pub path: &'a S,
     /// metadata attached to the import/include directive
@@ -105,7 +105,7 @@ pub struct Module<S, B = Vec<Def<S>>> {
 /// Tree of modules containing definitions.
 ///
 /// By convention, the last module contains a single definition that is the `main` filter.
-pub type Modules<S> = Vec<(File<S, String>, Module<S>)>;
+pub type Modules<S, P> = Vec<(File<S, P>, Module<S>)>;
 
 /// Errors occurring during loading of multiple modules.
 ///
@@ -115,7 +115,7 @@ pub type Modules<S> = Vec<(File<S, String>, Module<S>)>;
 /// a file `i.jq` that includes a non-existing module.
 /// If we then include all these files in our main program,
 /// [`Errors`] will contain each file with a different [`Error`].
-pub type Errors<S, E = Error<S>> = Vec<(File<S, String>, E)>;
+pub type Errors<S, P, E = Error<S>> = Vec<(File<S, P>, E)>;
 
 impl<S: core::ops::Deref<Target = str>, B> parse::Module<S, B> {
     fn map(
@@ -159,9 +159,10 @@ impl<S, B> Module<S, B> {
     }
 }
 
-type ReadFn = fn(Import<&str>) -> Result<File<String>, String>;
+type ReadResult<P> = Result<File<String, P>, String>;
+type ReadFn<P> = fn(Import<&str, P>) -> ReadResult<P>;
 
-impl<'s> Loader<&'s str, ReadFn> {
+impl<'s, P: Default> Loader<&'s str, P, ReadFn<P>> {
     /// Initialise the loader with prelude definitions.
     ///
     /// The prelude is a special module that is implicitly included by all other modules
@@ -222,7 +223,7 @@ fn expand_prefix(path: &Path, pre: &str, f: impl FnOnce() -> Option<PathBuf>) ->
 }
 
 #[cfg(feature = "std")]
-impl<'a> Import<'a, &'a str> {
+impl<'a> Import<'a, &'a str, PathBuf> {
     fn meta_paths(&self) -> Vec<PathBuf> {
         let paths = self.meta.as_ref().and_then(|meta| {
             let v = meta.obj_key("search")?;
@@ -271,20 +272,19 @@ impl<'a> Import<'a, &'a str> {
             .ok_or_else(|| "file not found".into())
     }
 
-    fn read(self, paths: &[PathBuf], ext: &str) -> Result<File<String>, String> {
+    fn read(self, paths: &[PathBuf], ext: &str) -> ReadResult<PathBuf> {
         use alloc::string::ToString;
         let path = self.find(paths, ext)?;
         let code = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
-        let path = path.display().to_string();
         Ok(File { code, path })
     }
 }
 
 /// Apply function to path of every imported data file, accumulating errors.
-pub fn import<S: Copy>(
-    mods: &Modules<S>,
-    mut f: impl FnMut(Import<S>) -> Result<(), String>,
-) -> Result<(), Errors<S>> {
+pub fn import<S: Copy, P: Clone>(
+    mods: &Modules<S, P>,
+    mut f: impl FnMut(Import<S, P>) -> Result<(), String>,
+) -> Result<(), Errors<S, P>> {
     let mut errs = Vec::new();
     let mut vals = Vec::new();
     for (mod_file, module) in mods {
@@ -307,34 +307,36 @@ pub fn import<S: Copy>(
     }
 }
 
-impl<S, R> Loader<S, R> {
+impl<S, P, R> Loader<S, P, R> {
     /// Provide a function to return the contents of included/imported module files.
     ///
     /// For every included/imported module, the loader will call this function to
     /// obtain the contents of the module.
     /// For example, if we have `include "foo"`, the loader calls `read("foo")`.
-    pub fn with_read<R2>(self, read: R2) -> Loader<S, R2> {
+    pub fn with_read<R2>(self, read: R2) -> Loader<S, P, R2> {
         let Self { mods, open, .. } = self;
         Loader { mods, read, open }
     }
+}
 
+impl<S, R> Loader<S, PathBuf, R> {
     /// Read the contents of included/imported module files by performing file I/O.
     #[cfg(feature = "std")]
     pub fn with_std_read(
         self,
         paths: &[PathBuf],
-    ) -> Loader<S, impl FnMut(Import<&str>) -> Result<File<String>, String> + '_> {
-        self.with_read(|import: Import<&str>| import.read(paths, "jq"))
+    ) -> Loader<S, PathBuf, impl FnMut(Import<&str, PathBuf>) -> ReadResult<PathBuf> + '_> {
+        self.with_read(|import: Import<&str, PathBuf>| import.read(paths, "jq"))
     }
 }
 
-impl<'s, R: FnMut(Import<&str>) -> Result<File<String>, String>> Loader<&'s str, R> {
+impl<'s, P: Clone + Eq, R: FnMut(Import<&str, P>) -> ReadResult<P>> Loader<&'s str, P, R> {
     /// Load a set of modules, starting from a given file.
     pub fn load(
         mut self,
         arena: &'s Arena,
-        file: File<&'s str, String>,
-    ) -> Result<Modules<&'s str>, Errors<&'s str>> {
+        file: File<&'s str, P>,
+    ) -> Result<Modules<&'s str, P>, Errors<&'s str, P>> {
         let result = parse_main(file.code)
             .and_then(|m| {
                 m.map(|path, meta| {
@@ -360,7 +362,7 @@ impl<'s, R: FnMut(Import<&str>) -> Result<File<String>, String>> Loader<&'s str,
         }
     }
 
-    fn find(&mut self, arena: &'s Arena, import: Import<&'s str>) -> Result<usize, String> {
+    fn find(&mut self, arena: &'s Arena, import: Import<&'s str, P>) -> Result<usize, String> {
         let file = (self.read)(import)?;
 
         let mut mods = self.mods.iter();
@@ -379,7 +381,7 @@ impl<'s, R: FnMut(Import<&str>) -> Result<File<String>, String>> Loader<&'s str,
                 self.find(arena, Import { parent, path, meta })
             })
         });
-        assert_eq!(self.open.pop().as_ref(), Some(&file.path));
+        assert!(self.open.pop().as_ref() == Some(&file.path));
 
         let id = self.mods.len();
         let path = file.path;

--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -319,9 +319,9 @@ impl<S, P, R> Loader<S, P, R> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<S, R> Loader<S, PathBuf, R> {
     /// Read the contents of included/imported module files by performing file I/O.
-    #[cfg(feature = "std")]
     pub fn with_std_read(
         self,
         paths: &[PathBuf],

--- a/jaq-core/tests/common/mod.rs
+++ b/jaq-core/tests/common/mod.rs
@@ -7,8 +7,7 @@ fn yields(x: Val, code: &str, ys: impl Iterator<Item = ValR>) {
 
     let arena = Arena::default();
     let loader = Loader::new([]);
-    let path = "".into();
-    let modules = loader.load(&arena, File { path, code }).unwrap();
+    let modules = loader.load(&arena, File { path: (), code }).unwrap();
     let filter = Compiler::<_, Native<_>>::default()
         .compile(modules)
         .unwrap();

--- a/jaq-json/tests/common/mod.rs
+++ b/jaq-json/tests/common/mod.rs
@@ -6,8 +6,7 @@ fn yields(x: Val, code: &str, ys: impl Iterator<Item = ValR>) {
 
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
-    let path = "".into();
-    let modules = loader.load(&arena, File { path, code }).unwrap();
+    let modules = loader.load(&arena, File { path: (), code }).unwrap();
     let filter = jaq_core::Compiler::default()
         .with_funs(jaq_std::funs().chain(jaq_json::funs()))
         .compile(modules)

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -271,9 +271,8 @@ fn parse(code: &str, vars: &[String]) -> Result<(Vec<Val>, Filter), Vec<FileRepo
     let vars: Vec<_> = vars.iter().map(|v| format!("${v}")).collect();
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
-    let path = ();
     let modules = loader
-        .load(&arena, File { path, code })
+        .load(&arena, File { path: (), code })
         .map_err(load_errors)?;
 
     let vals = Vec::new();

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -1,3 +1,8 @@
+#![no_std]
+extern crate alloc;
+
+use alloc::{borrow::ToOwned, format, string::ToString};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt::{self, Debug, Display, Formatter};
 use jaq_core::{compile, load, Ctx, Native, RcIter};
 use jaq_json::{fmt_str, Val};
@@ -214,7 +219,7 @@ fn read_str<'a>(
 
 fn raw_input(slurp: bool, input: &str) -> impl Iterator<Item = &str> {
     if slurp {
-        Box::new(std::iter::once(input))
+        Box::new(core::iter::once(input))
     } else {
         Box::new(input.lines()) as Box<dyn Iterator<Item = _>>
     }

--- a/jaq-std/tests/common/mod.rs
+++ b/jaq-std/tests/common/mod.rs
@@ -6,8 +6,7 @@ fn yields(x: Val, code: &str, ys: impl Iterator<Item = ValR>) {
 
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs());
-    let path = "".into();
-    let modules = loader.load(&arena, File { path, code }).unwrap();
+    let modules = loader.load(&arena, File { path: (), code }).unwrap();
     let filter = jaq_core::Compiler::default()
         .with_funs(jaq_std::funs())
         .compile(modules)

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, ValueEnum};
 use core::fmt::{self, Display, Formatter};
 use jaq_core::{compile, load, Ctx, Native, RcIter};
 use jaq_json::Val;
+use std::ffi::OsString;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::process::{ExitCode, Termination};
@@ -116,11 +117,11 @@ struct Cli {
     /// Filter to execute
     ///
     /// If this argument is not given, it is assumed to be `.`, the identity filter.
-    filter: Option<String>,
+    filter: Option<OsString>,
 
     /// Positional arguments, by default used as input files
     #[arg(name = "ARG")]
-    posargs: Vec<String>,
+    posargs: Vec<OsString>,
 }
 
 #[derive(Clone, ValueEnum)]
@@ -185,9 +186,9 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
         None => (Vec::new(), Filter::default()),
         Some(filter) => {
             let (path, code) = if cli.from_file {
-                (filter.clone(), std::fs::read_to_string(filter)?)
+                (filter.into(), std::fs::read_to_string(filter)?)
             } else {
-                ("<inline>".into(), filter.clone())
+                ("<inline>".into(), filter.clone().into_string().unwrap())
             };
 
             parse(&path, &code, &vars, &cli.library_path).map_err(Error::Report)?
@@ -204,7 +205,8 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
         let mut last = None;
         for file in files {
             let path = Path::new(file);
-            let file = load_file(path).map_err(|e| Error::Io(Some(file.to_string()), e))?;
+            let file =
+                load_file(path).map_err(|e| Error::Io(Some(path.display().to_string()), e))?;
             let inputs = read_slice(cli, &file);
             if cli.in_place {
                 // create a temporary file where output is written to
@@ -267,7 +269,8 @@ fn binds(cli: &Cli) -> Result<Vec<(String, Val)>, Error> {
     })?;
 
     let positional = if cli.args { &*cli.posargs } else { &[] };
-    let positional: Vec<_> = positional.iter().cloned().map(Val::from).collect();
+    let positional = positional.iter().cloned().map(|s| s.into_string().unwrap());
+    let positional: Vec<_> = positional.map(Val::from).collect();
 
     var_val.push(("ARGS".to_string(), args(&positional, &var_val)));
     let env = std::env::vars().map(|(k, v)| (k.into(), Val::from(v)));
@@ -288,7 +291,7 @@ fn args(positional: &[Val], named: &[(String, Val)]) -> Val {
 }
 
 fn parse(
-    path: &str,
+    path: &PathBuf,
     code: &str,
     vars: &[String],
     paths: &[PathBuf],
@@ -320,7 +323,7 @@ fn parse(
     Ok((vals, filter))
 }
 
-fn load_errors(errs: load::Errors<&str>) -> Vec<FileReports> {
+fn load_errors(errs: load::Errors<&str, PathBuf>) -> Vec<FileReports> {
     use load::Error;
 
     let errs = errs.into_iter().map(|(file, err)| {
@@ -335,7 +338,7 @@ fn load_errors(errs: load::Errors<&str>) -> Vec<FileReports> {
     errs.collect()
 }
 
-fn compile_errors(errs: compile::Errors<&str>) -> Vec<FileReports> {
+fn compile_errors(errs: compile::Errors<&str, PathBuf>) -> Vec<FileReports> {
     let errs = errs.into_iter().map(|(file, errs)| {
         let code = file.code;
         let errs = errs.into_iter().map(|e| report_compile(code, e)).collect();
@@ -422,7 +425,7 @@ fn collect_if<'a, T: FromIterator<T> + 'a, E: 'a>(
     }
 }
 
-type FileReports = (load::File<String>, Vec<Report>);
+type FileReports = (load::File<String, PathBuf>, Vec<Report>);
 
 #[derive(Debug)]
 enum Error {
@@ -457,7 +460,7 @@ impl Termination for Error {
                     for e in reports {
                         eprintln!("Error: {}", e.message);
                         let block = e.into_block(&idx);
-                        eprintln!("{}[{}]", block.prologue(), file.path);
+                        eprintln!("{}[{}]", block.prologue(), file.path.display());
                         eprintln!("{}{}", block, block.epilogue())
                     }
                 }
@@ -738,7 +741,7 @@ impl Report {
 }
 
 fn run_test(test: load::test::Test<String>) -> Result<(Val, Val), Error> {
-    let (ctx, filter) = parse("", &test.filter, &[], &[]).map_err(Error::Report)?;
+    let (ctx, filter) = parse(&PathBuf::new(), &test.filter, &[], &[]).map_err(Error::Report)?;
 
     let inputs = RcIter::new(Box::new(core::iter::empty()));
     let ctx = Ctx::new(ctx, &inputs);


### PR DESCRIPTION
This PR allows providing paths on the command-line that are not UTF-8, see #231.

To see this in action:

~~~ bash
mkdir foo
echo bar > foo/$(iconv -f UTF-8 -t UTF-16 <(echo 'abc#$%%^'))
cargo run -- -n --rawfile a foo/* '$a'
~~~

This should yield `"bar\n"`. Before this PR, this would fail with:

~~~
error: Invalid UTF-8 was detected in one or more arguments
~~~