### PR TITLE
perf: switch jaq-json hasher to foldhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,7 +260,7 @@ dependencies = [
 name = "jaq-json"
 version = "1.0.0-epsilon"
 dependencies = [
- "ahash",
+ "foldhash",
  "hifijson",
  "indexmap",
  "jaq-core",
@@ -691,23 +684,3 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -19,7 +19,7 @@ parse = ["hifijson"]
 jaq-core = { version = "2.0.0-epsilon", path = "../jaq-core" }
 jaq-std  = { version = "2.0.0-epsilon", path = "../jaq-std" }
 
-ahash = "0.8.6"
+foldhash = "0.1"
 hifijson = { version = "0.2.0", optional = true }
 indexmap = "2.0"
 serde_json = { version = "1.0.81", optional = true }

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -81,7 +81,7 @@ impl Type {
 }
 
 /// Order-preserving map
-type Map<K, V> = indexmap::IndexMap<K, V, ahash::RandomState>;
+type Map<K, V> = indexmap::IndexMap<K, V, foldhash::fast::RandomState>;
 
 /// Error that can occur during filter execution.
 pub type Error = jaq_core::Error<Val>;


### PR DESCRIPTION
This change replaces the hasher used in `jaq-json` with `foldhash`.

My personal motivation is that `foldhash` seems to be entering the ecosystem as an upcoming state-of-the-art, but there are other considerations:

- The original motivation for `ahash` way back in 0.5.0 was https://github.com/01mf02/jaq/commit/6114f309a066f33481f4d276dcd11c109ac87af9 and now `foldhash` has zero runtime dependencies, which allows dropping `zerocopy` from `Cargo.lock`
- Benchmarks show that `foldhash` is at worst comparable to `ahash`, so no apparent perf harm in the replacement

I am aware that this change might feel insubstantial or arbitrary, so please treat it as a loose suggestion and feel free to close immediately if uninterested :)