### PR TITLE
Rewrite command-line argument parser by hand.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,43 +84,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
- "clap_lex",
- "once_cell",
- "strsim",
- "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
 name = "codesnake"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,12 +150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,7 +194,6 @@ name = "jaq"
 version = "2.0.0-epsilon"
 dependencies = [
  "atty",
- "clap",
  "codesnake",
  "env_logger",
  "hifijson",
@@ -388,36 +344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,7 +408,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -502,23 +428,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -543,15 +452,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -612,7 +512,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -634,7 +534,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -672,15 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,5 +600,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]

--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -21,7 +21,6 @@ jaq-json = { version = "1.0.0-epsilon", path = "../jaq-json" }
 
 atty = "0.2"
 codesnake = { version = "0.2" }
-clap = { version = "4.0.0", features = ["derive"] }
 env_logger = { version = "0.10.0", default-features = false }
 hifijson = "0.2.0"
 log = { version = "0.4.17" }

--- a/jaq/src/cli.rs
+++ b/jaq/src/cli.rs
@@ -193,7 +193,7 @@ impl fmt::Display for Error {
             Self::Utf8(s) => write!(f, "invalid UTF-8: {s:?}"),
             Self::KeyValue(o) => write!(f, "{o} expects a key and a value"),
             Self::Int(o) => write!(f, "{o} expects an integer"),
-            Self::Path(o) => write!(f, "{o} expects an integer"),
+            Self::Path(o) => write!(f, "{o} expects a path"),
         }
     }
 }

--- a/jaq/src/cli.rs
+++ b/jaq/src/cli.rs
@@ -81,10 +81,10 @@ impl Cli {
     }
 
     fn long(&mut self, mode: &mut Mode, arg: &str, args: &mut ArgsOs) -> Result<(), Error> {
-        let int = |s: OsString| Some(s.into_string().ok()?.parse().ok()?);
+        let int = |s: OsString| s.into_string().ok()?.parse().ok();
         match arg {
             // handle all arguments after "--"
-            "" => args.try_for_each(|arg| self.positional(&mode, arg))?,
+            "" => args.try_for_each(|arg| self.positional(mode, arg))?,
 
             "null-input" => self.short('N', args)?,
             "raw-input" => self.short('R', args)?,
@@ -146,8 +146,10 @@ impl Cli {
     }
 
     pub fn parse() -> Result<Self, Error> {
-        let mut cli = Self::default();
-        cli.indent = 2;
+        let mut cli = Self {
+            indent: 2,
+            ..Self::default()
+        };
         let mut mode = Mode::Files;
         let mut args = std::env::args_os();
         args.next();

--- a/jaq/src/cli.rs
+++ b/jaq/src/cli.rs
@@ -1,0 +1,219 @@
+//! Command-line argument parsing
+use core::fmt;
+use std::env::ArgsOs;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+#[derive(Debug, Default)]
+pub struct Cli {
+    // Input options
+    pub null_input: bool,
+    /// When the option `--slurp` is used additionally,
+    /// then the whole input is read into a single string.
+    pub raw_input: bool,
+    /// When input is read from files,
+    /// jaq yields an array for each file, whereas
+    /// jq produces only a single array.
+    pub slurp: bool,
+
+    // Output options
+    pub compact_output: bool,
+    pub raw_output: bool,
+    /// This flag enables `--raw-output`.
+    pub join_output: bool,
+    pub in_place: bool,
+    pub color_output: bool,
+    pub monochrome_output: bool,
+    pub tab: bool,
+    pub indent: usize,
+
+    // Compilation options
+    pub from_file: bool,
+    /// If this option is given multiple times, all given directories are searched.
+    pub library_path: Vec<PathBuf>,
+
+    // Key-value options
+    pub arg: Vec<(String, String)>,
+    pub slurpfile: Vec<(String, OsString)>,
+    pub rawfile: Vec<(String, OsString)>,
+
+    // Positional arguments
+    /// If this argument is not given, it is assumed to be `.`, the identity filter.
+    pub filter: Option<Filter>,
+    pub files: Vec<PathBuf>,
+    pub args: Vec<String>,
+    //pub jsonargs: Vec<String>,
+    pub run_tests: Option<PathBuf>,
+    /// If there is some last output value `v`,
+    /// then the exit status code is
+    /// 1 if `v < true` (that is, if `v` is `false` or `null`) and
+    /// 0 otherwise.
+    /// If there is no output value, then the exit status code is 4.
+    ///
+    /// If any error occurs, then this option has no effect.
+    pub exit_status: bool,
+    pub version: bool,
+    pub help: bool,
+}
+
+#[derive(Debug)]
+pub enum Filter {
+    Inline(String),
+    FromFile(PathBuf),
+}
+
+impl Cli {
+    fn positional(&mut self, mode: &Mode, arg: OsString) -> Result<(), Error> {
+        if self.filter.is_none() {
+            self.filter = Some(if self.from_file {
+                Filter::FromFile(arg.into())
+            } else {
+                Filter::Inline(arg.into_string()?)
+            })
+        } else {
+            match mode {
+                Mode::Files => self.files.push(arg.into()),
+                Mode::Args => self.args.push(arg.into_string()?),
+                //Mode::JsonArgs => self.jsonargs.push(arg.into_string()?),
+            }
+        }
+        Ok(())
+    }
+
+    fn long(&mut self, mode: &mut Mode, arg: &str, args: &mut ArgsOs) -> Result<(), Error> {
+        let int = |s: OsString| Some(s.into_string().ok()?.parse().ok()?);
+        match arg {
+            // handle all arguments after "--"
+            "" => args.try_for_each(|arg| self.positional(&mode, arg))?,
+
+            "null-input" => self.short('N', args)?,
+            "raw-input" => self.short('R', args)?,
+            "slurp" => self.short('s', args)?,
+
+            "compact-output" => self.short('c', args)?,
+            "raw-output" => self.short('r', args)?,
+            "join-output" => self.short('j', args)?,
+            "in-place" => self.short('i', args)?,
+            "color-output" => self.short('C', args)?,
+            "monochrome-output" => self.short('M', args)?,
+            "tab" => self.tab = true,
+            "indent" => self.indent = args.next().and_then(int).ok_or(Error::Int("--indent"))?,
+            "library-path" => self.short('L', args)?,
+            "arg" => {
+                let (name, value) = parse_key_val("--arg", args)?;
+                self.arg.push((name, value.into_string()?));
+            }
+            "slurpfile" => self.slurpfile.push(parse_key_val("--slurpfile", args)?),
+            "rawfile" => self.rawfile.push(parse_key_val("--rawfile", args)?),
+
+            "args" => *mode = Mode::Args,
+            //"jsonargs" => *mode = Mode::JsonArgs,
+            "run-tests" => {
+                self.run_tests = Some(args.next().ok_or(Error::Path("--run-tests"))?.into())
+            }
+            "exit-status" => self.short('e', args)?,
+            "version" => self.short('V', args)?,
+            "help" => self.short('h', args)?,
+
+            arg => Err(Error::Flag(format!("--{arg}")))?,
+        }
+        Ok(())
+    }
+
+    fn short(&mut self, arg: char, args: &mut ArgsOs) -> Result<(), Error> {
+        match arg {
+            'n' => self.null_input = true,
+            'R' => self.raw_input = true,
+            's' => self.slurp = true,
+
+            'c' => self.compact_output = true,
+            'r' => self.raw_output = true,
+            'j' => self.join_output = true,
+            'i' => self.in_place = true,
+            'C' => self.color_output = true,
+            'M' => self.monochrome_output = true,
+
+            'f' => self.from_file = true,
+            'L' => self
+                .library_path
+                .push(args.next().ok_or(Error::Path("-L"))?.into()),
+            'e' => self.exit_status = true,
+            'V' => self.version = true,
+            'h' => self.help = true,
+            arg => Err(Error::Flag(format!("-{arg}")))?,
+        }
+        Ok(())
+    }
+
+    pub fn parse() -> Result<Self, Error> {
+        let mut cli = Self::default();
+        cli.indent = 2;
+        let mut mode = Mode::Files;
+        let mut args = std::env::args_os();
+        args.next();
+        while let Some(arg) = args.next() {
+            match arg.to_str() {
+                Some(s) => match s.strip_prefix("--") {
+                    Some(rest) => cli.long(&mut mode, rest, &mut args)?,
+                    None => match s.strip_prefix("-") {
+                        Some(rest) => rest.chars().try_for_each(|c| cli.short(c, &mut args))?,
+                        None => cli.positional(&mode, arg)?,
+                    },
+                },
+                None => cli.positional(&mode, arg)?,
+            }
+        }
+        Ok(cli)
+    }
+
+    pub fn color_if(&self, f: impl Fn() -> bool) -> bool {
+        if self.monochrome_output {
+            false
+        } else if self.color_output {
+            true
+        } else {
+            f()
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Flag(String),
+    Utf8(OsString),
+    KeyValue(&'static str),
+    Int(&'static str),
+    Path(&'static str),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Flag(s) => write!(f, "unknown flag: {s}"),
+            Self::Utf8(s) => write!(f, "invalid UTF-8: {s:?}"),
+            Self::KeyValue(o) => write!(f, "{o} expects a key and a value"),
+            Self::Int(o) => write!(f, "{o} expects an integer"),
+            Self::Path(o) => write!(f, "{o} expects an integer"),
+        }
+    }
+}
+
+/// Conversion of errors from [`OsString::into_string`].
+impl From<OsString> for Error {
+    fn from(e: OsString) -> Self {
+        Self::Utf8(e)
+    }
+}
+
+fn parse_key_val(arg: &'static str, args: &mut ArgsOs) -> Result<(String, OsString), Error> {
+    let err = || Error::KeyValue(arg);
+    let key = args.next().ok_or_else(err)?.into_string()?;
+    let val = args.next().ok_or_else(err)?;
+    Ok((key, val))
+}
+
+enum Mode {
+    Args,
+    //JsonArgs,
+    Files,
+}

--- a/jaq/src/cli.rs
+++ b/jaq/src/cli.rs
@@ -155,6 +155,7 @@ impl Cli {
         args.next();
         while let Some(arg) = args.next() {
             match arg.to_str() {
+                // we've got a valid UTF-8 argument here
                 Some(s) => match s.strip_prefix("--") {
                     Some(rest) => cli.long(&mut mode, rest, &mut args)?,
                     None => match s.strip_prefix("-") {
@@ -162,6 +163,9 @@ impl Cli {
                         None => cli.positional(&mode, arg)?,
                     },
                 },
+                // we've got invalid UTF-8, so it is no valid flag
+                // note that we do not check here whether arg starts with `-`,
+                // because this seems to be quite difficult to do in a portable way
                 None => cli.positional(&mode, arg)?,
             }
         }
@@ -214,6 +218,7 @@ fn parse_key_val(arg: &'static str, args: &mut ArgsOs) -> Result<(String, OsStri
     Ok((key, val))
 }
 
+/// Interpretation of positional arguments.
 enum Mode {
     Args,
     //JsonArgs,

--- a/jaq/src/help.txt
+++ b/jaq/src/help.txt
@@ -1,0 +1,38 @@
+Just Another Query Tool
+
+Usage: jaq [OPTION]... [FILTER] [ARG]...
+
+Arguments:
+  [FILTER]  Filter to execute
+  [ARG]...  Positional arguments, by default used as input files
+
+Input options:
+  -n, --null-input          Use null as single input value
+  -R, --raw-input           Read lines of the input as sequence of strings
+  -s, --slurp               Read (slurp) all input values into one array
+
+Output options:
+  -c, --compact-output      Print JSON compactly, omitting whitespace
+  -r, --raw-output          Write strings without escaping them with quotes
+  -j, --join-output         Do not print a newline after each value
+  -i, --in-place            Overwrite input file with its output
+  -C, --color-output        Always color output
+  -M, --monochrome-output   Do not color output
+      --tab                 Use tabs for indentation rather than spaces
+      --indent <N>          Use N spaces for indentation [default: 2]
+
+Compilation options:
+  -f, --from-file           Read filter from a file given by filter argument
+  -L, --library-path <DIR>  Search for modules and data in given directory
+
+Variable options:
+      --arg       <A> <V>   Set variable `$A` to string `V`
+      --slurpfile <A> <F>   Set variable `$A` to array containing the JSON values in file `F`
+      --rawfile   <A> <F>   Set variable `$A` to string containing the contents of file `F`
+      --args                Collect remaining positional arguments into `$ARGS.positional`
+
+Remaining options:
+      --run-tests <FILE>    Run tests from a file
+  -e, --exit-status         Use the last output value as exit status code
+  -V, --version             Print version
+  -h, --help                Print help

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> ExitCode {
     let cli = match Cli::parse() {
         Ok(cli) => cli,
         Err(e) => {
-            eprintln!("{e}");
+            eprintln!("Error: {e}");
             return ExitCode::from(2);
         }
     };


### PR DESCRIPTION
The motivation is to correctly parse `--args`. As a nice side effect, this eliminates the dependency on clap as well. See: <https://github.com/01mf02/jaq/issues/216#issuecomment-2480317387>