### PR TITLE
Fix --null-input flag

### DIFF
--- a/jaq/src/cli.rs
+++ b/jaq/src/cli.rs
@@ -87,7 +87,7 @@ impl Cli {
             // handle all arguments after "--"
             "" => args.try_for_each(|arg| self.positional(mode, arg))?,
 
-            "null-input" => self.short('N', args)?,
+            "null-input" => self.short('n', args)?,
             "raw-input" => self.short('R', args)?,
             "slurp" => self.short('s', args)?,
 


### PR DESCRIPTION
`--null-input` long form flag is currently mapped to the wrong short form flag:

```
❯ jaq --version
jaq 2.0.0

❯ jaq --null-input '.'
Error: unknown flag: -N

❯ jaq -n '.'
null
```