### PR TITLE
Fix --slurpfile flag

### DIFF
--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -138,7 +138,7 @@ fn binds(cli: &Cli) -> Result<Vec<(String, Val)>, Error> {
         let s = std::fs::read_to_string(path).map_err(|e| Error::Io(Some(format!("{path:?}")), e));
         Ok((k.to_owned(), Val::Str(s?.into())))
     });
-    let slurpfile = cli.rawfile.iter().map(|(k, path)| {
+    let slurpfile = cli.slurpfile.iter().map(|(k, path)| {
         let a = json_array(path).map_err(|e| Error::Io(Some(format!("{path:?}")), e));
         Ok((k.to_owned(), a?))
     });


### PR DESCRIPTION
`--slurpfile` is currently silently ignored due to a small typo:

```
❯ jaq --version
jaq 2.0.0

❯ jaq --slurpfile foo <(echo 1) -n '$foo'
Error: undefined variable
  ╭─[<inline>]
  │
1 │ $foo
  ┆ ──┬─
  ┆   │
  ┆   ╰── undefined variable
──╯
```