### PR TITLE
jaq-core/loader: be specific about input parameter for reader

### DIFF
--- a/jaq-core/src/load/mod.rs
+++ b/jaq-core/src/load/mod.rs
@@ -331,7 +331,7 @@ impl<S, R> Loader<S, PathBuf, R> {
     }
 }
 
-impl<'s, P: Clone + Eq, R: FnMut(Import<&str, P>) -> ReadResult<P>> Loader<&'s str, P, R> {
+impl<'s, P: Clone + Eq, R: FnMut(Import<&'s str, P>) -> ReadResult<P>> Loader<&'s str, P, R> {
     /// Load a set of modules, starting from a given file.
     pub fn load(
         mut self,


### PR DESCRIPTION
With this minor tweak, I can use `Import<&'s str, &'s str>`, which is useful when all file references live in a HashMap or similar structure.
