### PR TITLE
Correct printing of special Unicode characters in objects keys.

### DIFF
--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -945,11 +945,11 @@ impl fmt::Display for Val {
             }
             Self::Obj(o) => {
                 write!(f, "{{")?;
-                let mut iter = o.iter();
+                let mut iter = o.iter().map(|(k, v)| (Val::Str(k.clone()), v));
                 if let Some((k, v)) = iter.next() {
-                    write!(f, "{k:?}:{v}")?;
+                    write!(f, "{k}:{v}")?;
                 }
-                iter.try_for_each(|(k, v)| write!(f, ",{k:?}:{v}"))?;
+                iter.try_for_each(|(k, v)| write!(f, ",{k}:{v}"))?;
                 write!(f, "}}")
             }
         }

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -58,6 +58,7 @@ where
 }
 
 fn fmt_val(f: &mut Formatter, opts: &PpOpts, level: usize, v: &Val) -> fmt::Result {
+    let display = |s| FormatterFn(move |f: &mut Formatter| fmt_str(f, &escape(s)));
     match v {
         Val::Null => span(f, "null", "null"),
         Val::Bool(b) => span(f, "boolean", b),
@@ -65,10 +66,7 @@ fn fmt_val(f: &mut Formatter, opts: &PpOpts, level: usize, v: &Val) -> fmt::Resu
         Val::Float(x) if x.is_finite() => span_dbg(f, "number", x),
         Val::Float(_) => span(f, "null", "null"),
         Val::Num(n) => span(f, "number", n),
-        Val::Str(s) => {
-            let display = FormatterFn(|f: &mut Formatter| fmt_str(f, &escape(s)));
-            span(f, "string", display)
-        }
+        Val::Str(s) => span(f, "string", display(s)),
         Val::Arr(a) if a.is_empty() => write!(f, "[]"),
         Val::Arr(a) => {
             write!(f, "[")?;
@@ -79,7 +77,7 @@ fn fmt_val(f: &mut Formatter, opts: &PpOpts, level: usize, v: &Val) -> fmt::Resu
         Val::Obj(o) => {
             write!(f, "{{")?;
             fmt_seq(f, opts, level, &**o, |f, (k, val)| {
-                span_dbg(f, "key", escape(k))?;
+                span(f, "key", display(k))?;
                 write!(f, ":")?;
                 if !opts.compact {
                     write!(f, " ")?;

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -469,7 +469,7 @@ fn fmt_val(f: &mut Formatter, opts: &PpOpts, level: usize, v: &Val) -> fmt::Resu
         Val::Obj(o) => {
             '{'.bold().fmt(f)?;
             let kv = |f: &mut Formatter, (k, val): (&std::rc::Rc<String>, &Val)| {
-                write!(f, "{:?}:", k.bold())?;
+                write!(f, "{}:", Val::Str(k.clone()).bold())?;
                 if !opts.compact {
                     write!(f, " ")?;
                 }

--- a/jaq/tests/golden.rs
+++ b/jaq/tests/golden.rs
@@ -143,6 +143,13 @@ test!(
 );
 
 test!(
+    fmt_obj_key,
+    &["-c"],
+    r#"{"विश\u094dव": 1}"#,
+    r#"{"विश्व":1}"#
+);
+
+test!(
     mods,
     &["-c", "-L", "tests", r#"include "a"; [a, data, d]"#],
     "0",


### PR DESCRIPTION
This should address <https://github.com/01mf02/jaq/issues/209#issuecomment-2645713323>.