### PR TITLE
Handle break labels like variables.

### DIFF
--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -80,7 +80,7 @@ pub(crate) enum Term<T = TermId> {
     /// Singleton object (`{f: g}`)
     ObjSingle(T, T),
 
-    /// Bound variable (`$x`) or filter argument (`a`)
+    /// Bound variable (`$x`), label (`label $x`), or filter argument (`a`)
     Var(VarId),
     /// Call to a filter (`filter`, `filter(…)`)
     CallDef(TermId, Box<[Bind<T>]>, VarSkip, Option<Tailrec>),

--- a/jaq-core/src/exn.rs
+++ b/jaq-core/src/exn.rs
@@ -17,7 +17,7 @@ pub(crate) enum Inner<'a, V> {
     ///
     /// This is used internally to execute tail-recursive filters.
     /// If this can be observed by users, then this is a bug.
-    TailCall(&'a crate::compile::TermId, crate::Vars<'a, V>, V),
+    TailCall(&'a crate::compile::TermId, crate::filter::Vars<'a, V>, V),
     Break(usize),
 }
 

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -237,8 +237,8 @@ yields!(
 
 yields!(
     label_break_common,
-    "label $x | (def x: break $x; (label $y | x), 0)",
-    []
+    "[label $x | (def x: break $x; (label $y | x), 0)]",
+    json!([])
 );
 
 yields!(

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -236,6 +236,12 @@ yields!(
 );
 
 yields!(
+    label_break_common,
+    "label $x | (def x: break $x; (label $y | x), 0)",
+    []
+);
+
+yields!(
     try_catch_short_circuit,
     "[try (\"1\", \"2\", {}[0], \"4\") catch .]",
     ["1", "2", "cannot index {} with 0"]


### PR DESCRIPTION
The offset mechanism previously used to deal with `label ... break` yielded wrong outputs in certain situations. For example, `label $x | (def x: break $x; (label $y | x), 0)` yields `0` in jaq 2.1.0, whereas it should yield `empty` (like jq).

This PR replaces the offset mechanism completely by a substitution mechanism that assigns break labels a unique index on the current execution path. This uses to a large extent the existing infrastructure for variables. Consequently, this corrects the execution of `label ... break` expressions.

I discovered this issue while reworking the [formal jq specification](https://github.com/01mf02/jq-lang-spec/).