### PR TITLE
Buffer write operations when stdout is not a terminal.

### DIFF
--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -518,7 +518,7 @@ fn print(w: &mut (impl Write + ?Sized), cli: &Cli, val: &Val) -> io::Result<()> 
     }
 }
 
-fn with_stdout<T>(f: impl FnOnce(&mut dyn io::Write) -> T) -> T {
+fn with_stdout<T>(f: impl FnOnce(&mut dyn Write) -> T) -> T {
     let stdout = io::stdout();
     if stdout.is_terminal() {
         f(&mut stdout.lock())


### PR DESCRIPTION
In #136, @JustinAzoff remarked that output throughput can be increased by buffering, when the output device is not a terminal (TTY). This PR implements that strategy.