### PR TITLE
Implement updates with folding operators (reduce/foreach) on LHS.

### DIFF
--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -487,7 +487,7 @@ impl<F: FilterT<F>> FilterT<F> for Id {
             Ast::Fold(xs, pat, init, update, fold_type) => {
                 let xs = rc_lazy_list::List::from_iter(run_and_bind(xs, lut, cv.clone(), pat));
                 let rec = move |v| fold_update(lut, fold_type, update, v, xs.clone(), f.clone());
-                init.update(lut, cv.clone(), Box::new(rec))
+                init.update(lut, cv, Box::new(rec))
             }
 
             Ast::Id => f(cv.1),

--- a/jaq-core/tests/tests.rs
+++ b/jaq-core/tests/tests.rs
@@ -492,3 +492,21 @@ yields!(
 ]"#,
     [1, 3, 4, 7]
 );
+
+yields!(
+    reduce_update,
+    "[[1, 2]] | reduce (0, 1) as $p (.; .[$p]) += 1",
+    [[1, 3]]
+);
+
+yields!(
+    foreach_update,
+    "[[1, [2]]] | foreach (0, 1) as $p (.; .[$p]) += [3]",
+    json!([[1, [2, 3], 3]])
+);
+
+yields!(
+    foreach_update_proj,
+    "[[1, [[2]]]] | foreach (0, 1, 0) as $p (.; .[$p]; if $p == 0 then .[0] else {}[] as $x | . end) += 1",
+    json!([[2, [[3]]]])
+);


### PR DESCRIPTION
This PR enables updates with folding operators (`reduce` and `foreach`) on the left-hand side of updates.
This is something that jq cannot currently do.

# Motivation

The motivating case for this PR was the implementation of `getpath`. In jq, we can use `getpath` on the left-hand side of updates:

~~~
$ jq -nc '[[2, 3]] | getpath([0, 1]) += 1'
[[2,4]]
~~~

In jq, `getpath` is a builtin filter implemented in C.
In jaq, I tried to first implement `getpath` as definition, as such:

~~~ jq
def getpath($p): if $p != [] then .[$p[0]] | getpath($p[1:]) end;
~~~

This is a more convoluted version of the following:

~~~ jq
def getpath($path): reduce $path[] as $p (.; .[$p]);
~~~

The difference between the two versions is that the first version can be used on the left-hand side of updates, whereas the second version cannot:

~~~
$ jq -nc 'def getpath($p): if $p != [] then .[$p[0]] | getpath($p[1:]) end; [[2, 3]] | getpath([0, 1]) += 1'
[[2,4]]
$ jq -nc 'def getpath($path): reduce $path[] as $p (.; .[$p]); [[2, 3]] | getpath([0, 1]) += 1'
jq: error (at <unknown>): Invalid path expression near attempt to iterate through [0,1]
~~~

Unfortunately, while the first version can be used on the left-hand side of updates, it is significantly slower than the second version.

I then tried to implement `getpath` as native filter, like it is done in jq, but this got quite convoluted and required a breaking API change for achieving optimal performance (3eede6cb570cd9352b750fa5750606e32e2b2981).

This got me thinking: How about finally implementing update support for `reduce`/`foreach`? That way, we could use the more performant & simpler second definition of `getpath` **and** use it on the left-hand side of updates.

With this PR, jaq can do it:

~~~
$ jaq -nc 'def getpath($path): reduce $path[] as $p (.; .[$p]); [[2, 3]] | getpath([0, 1]) += 1'
[[2,4]]
~~~

# Implementation

This is a relatively straightforward implementation of what I described already one year ago in my [formal specification of the jq language](https://github.com/01mf02/jq-lang-spec) (section "Update semantics" > "Folding").

# Acknowledgements

Thanks to @osevill for having provided a convincing use case for `getpath` #277. This greatly motivated me to finally implement this functionality that was already a long time on my roadmap.