### PR TITLE
Path recording for filter execution

### DIFF
--- a/jaq-core/src/exn.rs
+++ b/jaq-core/src/exn.rs
@@ -27,13 +27,6 @@ pub(crate) enum Inner<'a, V> {
     Break(usize),
 }
 
-struct TailCall<'a, V> {
-    id: &'a crate::compile::TermId,
-    vars: crate::filter::Vars<'a, V>,
-    val: V,
-    path: Option<RcList<V>>,
-}
-
 impl<V> Exn<'_, V> {
     /// If the exception is an error, yield it, else yield the exception.
     pub(crate) fn get_err(self) -> Result<Error<V>, Self> {

--- a/jaq-core/src/exn.rs
+++ b/jaq-core/src/exn.rs
@@ -1,5 +1,6 @@
 //! Exceptions and errors.
 
+use crate::RcList;
 use alloc::{string::String, string::ToString, vec::Vec};
 use core::fmt::{self, Display};
 
@@ -17,8 +18,20 @@ pub(crate) enum Inner<'a, V> {
     ///
     /// This is used internally to execute tail-recursive filters.
     /// If this can be observed by users, then this is a bug.
-    TailCall(&'a crate::compile::TermId, crate::filter::Vars<'a, V>, V),
+    TailCall(
+        &'a crate::compile::TermId,
+        crate::filter::Vars<'a, V>,
+        V,
+        Option<RcList<V>>,
+    ),
     Break(usize),
+}
+
+struct TailCall<'a, V> {
+    id: &'a crate::compile::TermId,
+    vars: crate::filter::Vars<'a, V>,
+    val: V,
+    path: Option<RcList<V>>,
 }
 
 impl<V> Exn<'_, V> {

--- a/jaq-core/src/path.rs
+++ b/jaq-core/src/path.rs
@@ -1,7 +1,7 @@
 //! Paths and their parts.
 
 use crate::box_iter::{self, box_once, flat_map_with, map_with, then, BoxIter};
-use crate::val::{ValPR, ValR, ValT, ValX, ValXs};
+use crate::val::{ValR, ValT, ValX, ValXs};
 use crate::RcList;
 use alloc::{boxed::Box, vec::Vec};
 
@@ -79,7 +79,7 @@ impl<'a, V: ValT + 'a> Path<V> {
         run(self.0.into_iter(), v, |part, v| part.run(v))
     }
 
-    pub(crate) fn paths(self, vp: (V, RcList<V>)) -> BoxIter<'a, ValPR<V>> {
+    pub(crate) fn paths(self, vp: (V, RcList<V>)) -> Results<'a, (V, RcList<V>), V> {
         run(self.0.into_iter(), vp, |part, vp| part.paths(vp))
     }
 
@@ -134,7 +134,7 @@ impl<'a, V: ValT + 'a> Part<V> {
         }
     }
 
-    fn paths(&self, (v, p): (V, RcList<V>)) -> BoxIter<'a, ValPR<V>> {
+    fn paths(&self, (v, p): (V, RcList<V>)) -> Results<'a, (V, RcList<V>), V> {
         let cons = |p: RcList<V>| |v: V| (v, p.cons(V::from(self.as_ref().map(Clone::clone))));
         match self {
             Self::Index(idx) => box_once(v.index(idx).map(cons(p))),

--- a/jaq-core/src/rc_list.rs
+++ b/jaq-core/src/rc_list.rs
@@ -71,13 +71,22 @@ impl<T> List<T> {
         cur
     }
 
-    #[cfg(test)]
-    fn iter(&self) -> impl Iterator<Item = &T> {
-        use alloc::boxed::Box;
-        match &*self.0 {
-            Node::Cons(x, xs) => Box::new(core::iter::once(x).chain(xs.iter())),
-            Node::Nil => Box::new(core::iter::empty()) as Box<dyn Iterator<Item = _>>,
-        }
+    pub fn iter(&self) -> Iter<T> {
+        Iter(self)
+    }
+}
+
+pub struct Iter<'a, T>(&'a List<T>);
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        let (x, xs) = match &*self.0 .0 {
+            Node::Cons(x, xs) => (x, xs),
+            Node::Nil => return None,
+        };
+        self.0 = xs;
+        Some(x)
     }
 }
 

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -4,7 +4,8 @@
 //! you need to implement the [`ValT`] trait.
 
 use crate::box_iter::BoxIter;
-use crate::path::Opt;
+use crate::path::{self, Opt};
+use crate::RcList;
 use core::fmt::Display;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
@@ -14,6 +15,7 @@ use core::str::FromStr;
 
 /// Value or eRror.
 pub type ValR<V> = Result<V, crate::Error<V>>;
+pub type ValPR<V> = Result<(V, RcList<V>), crate::Error<V>>;
 /// Value or eXception.
 pub type ValX<'a, V> = Result<V, crate::Exn<'a, V>>;
 /// Stream of values and eXceptions.
@@ -31,6 +33,7 @@ pub trait ValT:
     + From<bool>
     + From<isize>
     + From<alloc::string::String>
+    + From<path::Part<Self>>
     + FromIterator<Self>
     + PartialEq
     + PartialOrd
@@ -50,6 +53,11 @@ pub trait ValT:
     ///
     /// This is used when creating values with the syntax `{k: v}`.
     fn from_map<I: IntoIterator<Item = (Self, Self)>>(iter: I) -> ValR<Self>;
+
+    /// Yield the key-value pairs of a value.
+    ///
+    /// This is used to collect the paths of `.[]`.
+    fn key_values(self) -> BoxIter<'static, Result<(Self, Self), crate::Error<Self>>>;
 
     /// Yield the children of a value.
     ///

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -5,7 +5,6 @@
 
 use crate::box_iter::BoxIter;
 use crate::path::{self, Opt};
-use crate::RcList;
 use core::fmt::Display;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
@@ -15,7 +14,6 @@ use core::str::FromStr;
 
 /// Value or eRror.
 pub type ValR<V> = Result<V, crate::Error<V>>;
-pub type ValPR<V> = Result<(V, RcList<V>), crate::Error<V>>;
 /// Value or eXception.
 pub type ValX<'a, V> = Result<V, crate::Exn<'a, V>>;
 /// Stream of values and eXceptions.

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -107,6 +107,16 @@ impl jaq_core::ValT for Val {
         Ok(Self::obj(iter.collect::<Result<_, _>>()?))
     }
 
+    fn key_values(self) -> Box<dyn Iterator<Item = Result<(Val, Val), Error>>> {
+        let arr_idx = |(i, x)| Ok((Self::Int(i as isize), x));
+        let obj_idx = |(k, v)| Ok((Self::Str(k), v));
+        match self {
+            Self::Arr(a) => Box::new(rc_unwrap_or_clone(a).into_iter().enumerate().map(arr_idx)),
+            Self::Obj(o) => Box::new(rc_unwrap_or_clone(o).into_iter().map(obj_idx)),
+            _ => box_once(Err(Error::typ(self, Type::Iter.as_str()))),
+        }
+    }
+
     fn values(self) -> Box<dyn Iterator<Item = ValR>> {
         match self {
             Self::Arr(a) => Box::new(rc_unwrap_or_clone(a).into_iter().map(Ok)),
@@ -668,6 +678,14 @@ impl From<f64> for Val {
 impl From<String> for Val {
     fn from(s: String) -> Self {
         Self::Str(Rc::new(s))
+    }
+}
+
+impl From<jaq_core::path::Part<Val>> for Val {
+    fn from(p: jaq_core::path::Part<Val>) -> Self {
+        match p {
+            _ => todo!(),
+        }
     }
 }
 

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -681,10 +681,15 @@ impl From<String> for Val {
     }
 }
 
-impl From<jaq_core::path::Part<Val>> for Val {
-    fn from(p: jaq_core::path::Part<Val>) -> Self {
+impl From<path::Part<Val>> for Val {
+    fn from(p: path::Part<Val>) -> Self {
+        let kv = |(k, v): (&str, Option<_>)| v.map(|v| (k.to_string().into(), v));
         match p {
-            _ => todo!(),
+            path::Part::Index(i) => i,
+            path::Part::Range(start, end) => {
+                let kvs = [("start", start), ("end", end)];
+                Val::obj(kvs.into_iter().flat_map(kv).collect())
+            }
         }
     }
 }

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -325,6 +325,17 @@ fn base_run<V: ValT, F: FilterT<V = V>>() -> Box<[Filter<RunPtr<V, F>>]> {
                     .map(|r| r.map_err(|e| Exn::from(Error::str(e)))),
             )
         }),
+        ("path", f(), |lut, mut cv| {
+            let (f, fc) = cv.0.pop_fun();
+            let cvp = (fc, (cv.1, Default::default()));
+            Box::new(f.paths(lut, cvp).map(|vp| {
+                vp.map(|(_v, path)| {
+                    let mut path: Vec<_> = path.iter().cloned().collect();
+                    path.reverse();
+                    path.into_iter().collect()
+                })
+            }))
+        }),
         ("floor", v(0), |_, cv| bome(cv.1.round(f64::floor))),
         ("round", v(0), |_, cv| bome(cv.1.round(f64::round))),
         ("ceil", v(0), |_, cv| bome(cv.1.round(f64::ceil))),


### PR DESCRIPTION
This PR adds support for the `path(f)` filter.
This makes several things possible in jaq; in particular, path-based updates à la `jq`!
However, the execution of `f |= g` will keep using non-path-based updates due to their greater performance and resistance to iterator invalidation problems.
Still, it is possible to define `def update(f; g): reduce path(f) as $p (.; getpath($p) |= g);` and have `update(f; g)` in jaq do mostly the same thing as `f |= g` in jq. Be aware, however, that this does not attempt to work around iterator invalidation issues the same way as `jq` does; to avoid these issues, I advise you to use jaq's `f |= g`, which is more robust.

## Design

Before implementing this, I made a small experiment where I tried to give a rough estimation of the performance overhead if I would change jaq such that `path(...)` execution and normal execution would *share the same code*.
For that, I modified the `range` function https://github.com/01mf02/jaq/blob/8c5131b4060d95856cc347e98baaf270b5bd43a8/jaq-std/src/lib.rs#L391 to carry with it some kind of "bogus path". The results are:

$ hyperfine "target/release/jaq -n '[range(10000000)] | length'"

`Box::new(range(Ok(from), to, by))` (original):
  Time (mean ± σ):     418.0 ms ±   1.4 ms    [User: 381.0 ms, System: 34.3 ms]
  Range (min … max):   415.7 ms … 420.4 ms    10 runs

`Box::new(range(Ok(from), to, by).map(|v| (v, None as Option<String>)).map(|(v, s)| v))`:
  Time (mean ± σ):     469.1 ms ±   4.7 ms    [User: 432.0 ms, System: 34.5 ms]
  Range (min … max):   460.3 ms … 475.9 ms    10 runs

`Box::new(range(Ok(from), to, by).map(|v| (v, Some(String::new()))).map(|(v, s)| v))`:
  Time (mean ± σ):     472.4 ms ±   3.0 ms    [User: 434.6 ms, System: 35.0 ms]
  Range (min … max):   469.2 ms … 476.5 ms    10 runs

In a nutshell, that means that calculating paths everywhere --- even when you do not need them --- costs about 12% (469ms / 418ms) of performance overhead. That's too much of performance overhead to accept for me.

Therefore, I opted for a design where executing `path(f)` uses code different from the normal execution code (that would be called when just executing `f` on its own). That entails some code duplication, but it's not that bad. I tried to share as much code as possible between the path and normal execution code, even if that required giving some functions even more complex function signatures. Perhaps as a side-effect, this makes these functions more difficult to misuse, even if it also makes them harder to understand.

## Compatibility

There is currently a small difference between the `path(f)` semantics of `jaq` and `jq`: In jaq, if a subexpression of `f` is executed and it does return a non-path value, then an error is thrown, whereas in jq, an error is only thrown if such a non-path value is actually returned from `f`.
To see the difference: `jq -n 'path([] | empty)'` returns no output, whereas `jaq -n 'path([] | empty)'` returns an error.
This difference could be eliminated, but it would cost some performance and memory, because instead of returning a path `RcList<V>` (paths are implemented as linked lists), we would need to return an `Option<RcList<V>>` everywhere.
That would also make the implementation a bit more awkward and the API more complex.
Given that I suppose that few people use such paths, I do not think it is worth the effort. But if you are concerned, feel free to speak up.

## API

This change breaks the API of `jaq-core`; therefore, it will be part of jaq 3.0.
There are two main changes:

- `jaq_core::ValT` will need to implement `key_values` and `From<jaq_core::path::Part<Self>>`.
- Native filters constructed using `with_update` will need to also provide an implementation for `paths`.