### PR TITLE
Ensure no file handles remain open during in-place persist (closes #292).

### DIFF
--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -107,6 +107,7 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
                 })?;
 
                 // replace the input file with the temporary file
+                std::mem::drop(file);
                 let perms = std::fs::metadata(path)?.permissions();
                 tmp.persist(path).map_err(Error::Persist)?;
                 std::fs::set_permissions(path, perms)?;


### PR DESCRIPTION
Hey there, here's the fix for persisting files using the in-place option on Windows. This will ensure that the file handle used for processing of the file will be released before persisting to disk from the temp directory.

See output below:

```
~\source\jaq on  avoid-open-handles-during-persist [?] via 🦀 v1.88.0 took 3s
🕙 [ 09:48:19 AM ] ❯ git co main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

~\source\jaq on  main [?] via 🦀 v1.88.0
🕙 [ 09:48:26 AM ] ❯ cp ..\firefox-settings\bookmarks.json .

~\source\jaq on  main [?] via 🦀 v1.88.0
🕙 [ 09:48:31 AM ] ❯ cargo run -- -i . bookmarks.json
   Compiling jaq v2.2.0 (C:\Users\Fots\source\jaq\jaq)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.30s
     Running `target\debug\jaq.exe -i . bookmarks.json`
Error: failed to persist temporary file: Access is denied. (os error 5)
error: process didn't exit successfully: `target\debug\jaq.exe -i . bookmarks.json` (exit code: 2)

~\source\jaq on  main [?] via 🦀 v1.88.0 took 4s
🕙 [ 09:48:38 AM ] ❯ git co avoid-open-handles-during-persist
Switched to branch 'avoid-open-handles-during-persist'
Your branch is up to date with 'origin/avoid-open-handles-during-persist'.

~\source\jaq on  avoid-open-handles-during-persist [?] via 🦀 v1.88.0
🕙 [ 09:48:40 AM ] ❯ cp ..\firefox-settings\bookmarks.json .

~\source\jaq on  avoid-open-handles-during-persist [?] via 🦀 v1.88.0
🕙 [ 09:48:43 AM ] ❯ cargo run -- -i . bookmarks.json
   Compiling jaq v2.2.0 (C:\Users\Fots\source\jaq\jaq)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.20s
     Running `target\debug\jaq.exe -i . bookmarks.json`
```

Unfortunately, this does lead to a tiny bit of repeated code, but I think this is somewhat unavoidable.

Cheers
Fotis