### PR TITLE
Correctly handle labels inside of native function arguments

### DIFF
--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -244,6 +244,17 @@ yields!(round_floor, "-1.4 | round", -1);
 yields!(floor_floor, "-1.4 | floor", -2);
 yields!(ceili_floor, "-1.4 | ceil ", -1);
 
+yields!(
+    sort_break_out,
+    "[1, 2] | (label $x | sort_by(label $y | ., break $x)), 3",
+    3
+);
+yields!(
+    sort_break_in,
+    "[1, 2] | label $x | sort_by(label $y | ., break $y)",
+    [1, 2]
+);
+
 #[test]
 fn startswith() {
     give(json!("foobar"), r#"startswith("")"#, json!(true));


### PR DESCRIPTION
Before, when a new label was declared inside a native function argument, breaking to a label declared outside the call to the native function could be caught by the wrong label.
As example, consider the following filter:

~~~ jq
[1, 2] | label $x | sort_by(label $y | break $x)
~~~

Before this change, this would (erroneously) yield `[1, 2]`. After this change, this (correctly) yields no output at all.