### PR TITLE
Prototype of an `eval`-supporting jaq with `Rc<Lut>`

### DIFF
--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -34,7 +34,7 @@ impl<F> Default for Lut<F> {
 
 impl<F> Default for Filter<F> {
     fn default() -> Self {
-        Self(TermId(0), Lut::new([Term::Id].into()))
+        Self(TermId(0), Lut::new([Term::Id].into()).into())
     }
 }
 
@@ -544,7 +544,7 @@ impl<'s, F> Compiler<&'s str, F> {
             assert!(main_sig.matches("main", &[]));
             assert!(!main_def.rec && main_def.tailrec);
             //std::println!("main: {:?}", main_def.id);
-            Ok(Filter(main_def.id, self.lut.map_funs(|(_sig, f)| f)))
+            Ok(Filter(main_def.id, self.lut.map_funs(|(_sig, f)| f).into()))
         } else {
             Err(errs)
         }


### PR DESCRIPTION
`eval/1` is a very interesting filter that is implemented in `fq`. It allows the execution of a jq program given as a string, such as:

~~~
$ fq -n 'eval(".+1")'
1
~~~

The fun part is that `eval` works lazily; that is, it can yield infinitely many outputs that are lazily evaluated:

~~~
$ fq -n 'eval("recurse(.+1)")' | head -5
null
1
2
3
4
~~~

Having `eval` is nice, because it allows to [define a REPL filter](https://github.com/01mf02/jaq/pull/303#issuecomment-3034896868) by definition in a very elegant way.
However, supporting `eval` in jaq is a challenge. That's because currently jaq assumes that the program data remains the same during the whole program execution.
I'll discuss two approaches to break with this assumption with the goal to make jaq support `eval`.

## First approach: Make lifetimes more flexible

I made a little [good proto](https://www.folklore.org/I'll_Be_Your_Best_Friend.html) as follows:

~~~ rust
// bogus placeholder types
type Val = String;
type Id = usize;
// `'f` is the lifetime of program data and `'i` is the lifetime of the input values
type Cv<'f, 'i> = (&'f Vec<Id>, &'i str);

fn run<'f, 'i: 'f>(id: Id, cv: Cv<'f, 'i>) -> Box<dyn Iterator<Item = Val> + 'i> {
    Box::new(cartesian(id, id, cv).map(|(l, _r)| l))
}

fn concat<'f, 'i: 'f>(l: Id, r: Id, cv: Cv<'f, 'i>) -> Box<dyn Iterator<Item = Val> + 'i> {
    Box::new(run(l, cv.clone()).chain(run(r, cv)))
}

fn cartesian<'f, 'i: 'f>(
    l: Id,
    r: Id,
    cv: Cv<'f, 'i>,
) -> Box<dyn Iterator<Item = (Val, Val)> + 'i> {
    let l = run(l, cv.clone());
    Box::new(l.flat_map(move |l| Box::new(run(r, cv.clone()).map(move |r| (l.clone(), r)))))
}

fn eval<'f, 'i: 'f>(id: Id, cv: Cv<'f, 'i>) -> Box<dyn Iterator<Item = Val> + 'i> {
    let lut = cv.0.clone();
    let cv2 = (&lut, cv.1);
    run(id, cv2)
}
~~~


Problem is, that it does not compile:

~~~
error: lifetime may not live long enough
  --> src/main.rs:19:5
   |
13 | fn cartesian<'f, 'i: 'f>(
   |              --  -- lifetime `'i` defined here
   |              |
   |              lifetime `'f` defined here
...
19 |     Box::new(l.flat_map(move |l| Box::new(run(r, cv.clone()).map(move |r| (l.clone(), r)))))
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'i` but it is returning data with lifetime `'f`
   |
   = help: consider adding the following bound: `'f: 'i`
~~~

The problem here is the nested call to `run` inside `flat_map`: Because `Cv<'f, 'i>` can live only as long as `'f` (because it contains a reference to it), the whole iterator can also only live as long as `'f`. But the function signature specifies that it lives as long as `'i`, and `'i` outlives `'f`, so we have a contradiction.

If we change the function signatures to return `Box<dyn Iterator<Item = Val> + 'f>` instead (`'f` instead of `'i`), then `eval` does not compile anymore, because we capture the temporarily created filter and make the lifetime depend on it, which is not what we want.

So the approach to extend jaq's execution model with more complex lifetimes to support `eval` has failed.

## Second approach: Using `Rc<Lut>` instead of `&'a Lut`

The second approach is what is implemented in this PR, at least enough to make a few performance measurements.
It replaces `&'a Lut` with `Rc<Lut>`, which allows to run a filter with substituted program data and combine its outputs with that of other filters. Just what we need to run `eval`.

How does it perform?

~~~
$ hyperfine -L jaq jaq-paths,jaq-rclut "target/release/{jaq} -n 'def nats: if . < 1000000 then ., (.+1 | nats) else . end; [nats] | length'"
Benchmark 1: target/release/jaq-paths -n 'def nats: if . < 1000000 then ., (.+1 | nats) else . end; [nats] | length'
  Time (mean ± σ):     415.5 ms ±   7.1 ms    [User: 408.1 ms, System: 5.5 ms]
  Range (min … max):   407.2 ms … 425.4 ms    10 runs
 
Benchmark 2: target/release/jaq-rclut -n 'def nats: if . < 1000000 then ., (.+1 | nats) else . end; [nats] | length'
  Time (mean ± σ):     446.8 ms ±   5.2 ms    [User: 441.4 ms, System: 3.2 ms]
  Range (min … max):   442.3 ms … 455.5 ms    10 runs
 
Summary
  target/release/jaq-paths -n 'def nats: if . < 1000000 then ., (.+1 | nats) else . end; [nats] | length' ran
    1.08 ± 0.02 times faster than target/release/jaq-rclut -n 'def nats: if . < 1000000 then ., (.+1 | nats) else . end; [nats] | length'
~~~

So on this very simple benchmark, the `Rc<Lut>` approach is about 7.5% slower than the regular approach. Even if it does not use `eval` at all. That's because we have do do more expensive cloning of reference-counted pointers at many steps.

I'm currently not sure whether this overhead is worth the benefit of being able to implement `eval` in jaq.
Making this prototype into a fully functional implementation would also require adding quite a bit of `Rc` throughout the core evaluation code (especially to handle patterns and filter arguments, which could turn out to be a bit hairy, even though it's all doable), which could further degrade performance for certain cases.

All in all, I'm not sure yet about this change. I leave this PR open as a place of discussion, and also that I do not wonder in three months why this first approach did not work after all. :)