### PR TITLE
add toboolean/0 and error handling for conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Their definitions are at [`std.jq`](jaq-std/src/std.jq).
 - [x] Type (`type`)
 - [x] Filtering (`select(. >= 0)`)
 - [x] Selection (`values`, `nulls`, `booleans`, `numbers`, `strings`, `arrays`, `objects`, `iterables`, `scalars`)
-- [x] Conversion (`tostring`, `tonumber`)
+- [x] Conversion (`tostring`, `tonumber`, `toboolean`)
 - [x] Iterable filters (`map(.+1)`, `map_values(.+1)`, `add`, `join("a")`)
 - [x] Array filters (`transpose`, `first`, `last`, `nth(10)`, `flatten`, `min`, `max`)
 - [x] Object-array conversion (`to_entries`, `from_entries`, `with_entries`)

--- a/jaq-json/src/defs.jq
+++ b/jaq-json/src/defs.jq
@@ -1,12 +1,7 @@
 # Conversion
-def tonumber: if (isnumber | not) then
-  fromjson |
-  if (isnumber | not) then error("cannot parse number") end
-end;
-def toboolean: if (isboolean | not) then
-  fromjson |
-  if (isboolean | not) then error("cannot parse boolean") end
-end;
+def totype(p; e): if p then . else fromjson | if p then . else e end end;
+def tonumber : totype(isnumber ; error("cannot parse as number" ));
+def toboolean: totype(isboolean; error("cannot parse as boolean"));
 
 # Arrays
 def transpose: [range([.[] | length] | max) as $i | [.[][$i]]];

--- a/jaq-json/src/defs.jq
+++ b/jaq-json/src/defs.jq
@@ -1,5 +1,12 @@
 # Conversion
-def tonumber: if isnumber then . else fromjson end;
+def tonumber: if (isnumber | not) then
+  fromjson |
+  if (isnumber | not) then error("cannot parse number") end
+end;
+def toboolean: if (isboolean | not) then
+  fromjson |
+  if (isboolean | not) then error("cannot parse boolean") end
+end;
 
 # Arrays
 def transpose: [range([.[] | length] | max) as $i | [.[][$i]]];

--- a/jaq-json/tests/funs.rs
+++ b/jaq-json/tests/funs.rs
@@ -84,6 +84,32 @@ fn tojson() {
 }
 
 #[test]
+fn tonumber() {
+    give(json!(1.0), "tonumber", json!(1.0));
+    give(json!("1.0"), "tonumber", json!(1.0));
+    give(json!("42"), "tonumber", json!(42));
+    give(json!("null"), "try tonumber catch -7", json!(-7));
+    give(json!("true"), "try tonumber catch -7", json!(-7));
+    give(json!("str"), "try tonumber catch -7", json!(-7));
+    give(json!("\"str\""), "try tonumber catch -7", json!(-7));
+    give(json!("[3, 4]"), "try tonumber catch -7", json!(-7));
+    give(json!("{\"a\": 1}"), "try tonumber catch -7", json!(-7));
+}
+
+#[test]
+fn toboolean() {
+    give(json!(false), "toboolean", json!(false));
+    give(json!("true"), "toboolean", json!(true));
+    give(json!("false"), "toboolean", json!(false));
+    give(json!("null"), "try toboolean catch -7", json!(-7));
+    give(json!("3"), "try toboolean catch -7", json!(-7));
+    give(json!("str"), "try toboolean catch -7", json!(-7));
+    give(json!("\"str\""), "try toboolean catch -7", json!(-7));
+    give(json!("[3, 4]"), "try toboolean catch -7", json!(-7));
+    give(json!("{\"a\": 1}"), "try toboolean catch -7", json!(-7));
+}
+
+#[test]
 fn math_rem() {
     // generated with this command with modification for errors and float rounding
     // cargo run -- -rn 'def f: -2, -1, 0, 2.1, 3, 2000000001; f as $a | f as $b | "give!(json!(null), \"\($a) / \($b)\", \(try ($a % $b) catch tojson));"'


### PR DESCRIPTION
Previously, passing a string representation of anything to `tonumber` would succeed; now it actually has to be a number or a string parseable as a number.

Added the missing `toboolean` while we're in the vicinity.

Includes tests.