### PR TITLE
Add parsing example

### DIFF
--- a/jaq-core/examples/parse.rs
+++ b/jaq-core/examples/parse.rs
@@ -1,0 +1,10 @@
+//! Parse a filter from standard input and output its AST.
+
+use jaq_core::load::{lex::Lexer, parse::Parser};
+
+fn main() {
+    let s = std::io::read_to_string(std::io::stdin()).unwrap();
+    let tokens = Lexer::new(&s).lex().unwrap();
+    let tm = Parser::new(&tokens).parse(Parser::term).unwrap();
+    println!("{tm:?}");
+}


### PR DESCRIPTION
This is used by the toy interpreter [`ujq`](https://github.com/01mf02/jq-lang-spec/tree/main/ujq).