### PR TITLE
feat: Add support for BSON file format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +62,41 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash",
+ "base64",
+ "bitvec",
+ "getrandom 0.2.16",
+ "getrandom 0.3.3",
+ "hex",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
+]
 
 [[package]]
 name = "bumpalo"
@@ -114,6 +162,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "dirs"
@@ -197,6 +254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,9 +279,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -232,6 +297,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hifijson"
@@ -294,6 +365,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "jaq"
 version = "2.3.0"
 dependencies = [
+ "bson",
  "codesnake",
  "dirs",
  "env_logger",
@@ -306,6 +378,7 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "rustyline",
+ "serde_json",
  "tempfile",
  "unicode-width",
  "yansi",
@@ -462,6 +535,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +560,21 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -505,6 +599,41 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "redox_users"
@@ -578,6 +707,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +732,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -616,6 +755,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -648,6 +793,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -685,6 +861,24 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -933,7 +1127,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -14,10 +14,11 @@ rust-version = "1.70"
 [features]
 default = ["parse"]
 parse = ["hifijson"]
+serde_json = ["dep:serde_json"]
 
 [dependencies]
-jaq-core = { version = "2.1.0", path = "../jaq-core" }
-jaq-std  = { version = "2.1.0", path = "../jaq-std" }
+jaq-core = { version = "2.2.1", path = "../jaq-core" }
+jaq-std  = { version = "2.1.2", path = "../jaq-std" }
 
 foldhash = { version = "0.1", default-features = false }
 hifijson = { version = "0.2.0", default-features = false, features = ["alloc"], optional = true }

--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.70"
 default = ["mimalloc"]
 
 [dependencies]
-jaq-core = { version = "2.1.1", path = "../jaq-core" }
-jaq-std  = { version = "2.1.0", path = "../jaq-std" }
-jaq-json = { version = "1.1.1", path = "../jaq-json" }
+jaq-core = { version = "2.2.1", path = "../jaq-core" }
+jaq-std  = { version = "2.1.2", path = "../jaq-std" }
+jaq-json = { version = "1.1.3", path = "../jaq-json", features = ["serde_json"] }
 
 codesnake = { version = "0.2" }
 dirs = { version = "6.0" }
@@ -31,3 +31,5 @@ rustyline = { version = "13.0.0", default-features = false, features = ["with-fi
 tempfile = "3.3.0"
 unicode-width = "0.1.13"
 yansi = "1.0.1"
+bson = "2.15.0"
+serde_json = "1.0"

--- a/jaq/src/bson.rs
+++ b/jaq/src/bson.rs
@@ -1,0 +1,64 @@
+use jaq_json::Val;
+use std::io;
+use std::iter;
+
+pub fn bson_stream(bytes: &[u8]) -> impl Iterator<Item = io::Result<Val>> + '_ {
+    let mut cursor = io::Cursor::new(bytes);
+    iter::from_fn(move || {
+        if cursor.position() == bytes.len() as u64 {
+            return None;
+        }
+
+        match bson::Document::from_reader(&mut cursor) {
+            Ok(doc) => {
+                let bson_val = bson::Bson::Document(doc);
+                let serde_val = bson_val.into_canonical_extjson();
+                Some(Ok(Val::from(serde_val)))
+            }
+            Err(e) => {
+                cursor.set_position(bytes.len() as u64);
+                Some(Err(io::Error::new(io::ErrorKind::InvalidData, e)))
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bson::{doc, oid::ObjectId, DateTime};
+    use jaq_json::Val;
+    use serde_json::json;
+
+    #[test]
+    fn test_bson_stream_simple() {
+        let doc = doc! { "hello": "world" };
+        let mut bson_bytes = Vec::new();
+        doc.to_writer(&mut bson_bytes).unwrap();
+
+        let mut vals = bson_stream(&bson_bytes);
+        let val = vals.next().unwrap().unwrap();
+
+        let expected_val = Val::from(json!({"hello": "world"}));
+        assert_eq!(val, expected_val);
+        assert!(vals.next().is_none());
+    }
+
+    #[test]
+    fn test_bson_extended_types() {
+        let id = ObjectId::new();
+        let dt = DateTime::now();
+        let doc = doc! { "_id": id, "date": dt };
+        let mut bson_bytes = Vec::new();
+        doc.to_writer(&mut bson_bytes).unwrap();
+
+        let mut vals = bson_stream(&bson_bytes);
+        let val = vals.next().unwrap().unwrap();
+
+        let expected_val = Val::from(json!({
+            "_id": { "$oid": id.to_hex() },
+            "date": { "$date": { "$numberLong": dt.timestamp_millis().to_string() } }
+        }));
+        assert_eq!(val, expected_val);
+    }
+}

--- a/jaq/src/cli.rs
+++ b/jaq/src/cli.rs
@@ -4,7 +4,7 @@ use std::env::ArgsOs;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Cli {
     // Input options
     pub null_input: bool,
@@ -15,6 +15,8 @@ pub struct Cli {
     /// jaq yields an array for each file, whereas
     /// jq produces only a single array.
     pub slurp: bool,
+
+    pub bson_input: bool,
 
     // Output options
     pub compact_output: bool,
@@ -58,7 +60,7 @@ pub struct Cli {
     pub help: bool,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Filter {
     Inline(String),
     FromFile(PathBuf),
@@ -91,6 +93,7 @@ impl Cli {
             "null-input" => self.short('n', args)?,
             "raw-input" => self.short('R', args)?,
             "slurp" => self.short('s', args)?,
+            "bson-input" => self.bson_input = true,
 
             "compact-output" => self.short('c', args)?,
             "raw-output" => self.short('r', args)?,
@@ -133,6 +136,7 @@ impl Cli {
             'n' => self.null_input = true,
             'R' => self.raw_input = true,
             's' => self.slurp = true,
+            'b' => self.bson_input = true,
 
             'c' => self.compact_output = true,
             'r' => self.raw_output = true,

--- a/jaq/src/help.txt
+++ b/jaq/src/help.txt
@@ -10,6 +10,7 @@ Input options:
   -n, --null-input          Use null as single input value
   -R, --raw-input           Read lines of the input as sequence of strings
   -s, --slurp               Read (slurp) all input values into one array
+  -b, --bson-input            Read input as BSON // -> AGGIUNGI QUESTA RIGA
 
 Output options:
   -c, --compact-output      Print JSON compactly, omitting whitespace


### PR DESCRIPTION
This PR introduces support for the BSON (Binary JSON) format, allowing `jaq` to process BSON files and streams.

### Motivation

BSON is a widely used data serialization format, especially in conjunction with MongoDB. Extending `jaq`'s capabilities to handle BSON makes it a more versatile tool for developers working in these ecosystems.

### Implementation

The implementation takes a non-invasive approach by decoding BSON data into a JSON string representation before passing it to the existing filter engine. This allows `jaq` to leverage its powerful JSON processing and rendering logic without modification.

Specifically, BSON documents are converted to their **Canonical Extended JSON** string representation.

### Key Changes

-   **New CLI Flags:** Adds a `--bson-input` (short: `-b`) flag to explicitly treat input as BSON.
-   **Automatic Detection:** Automatically detects files with the `.bson` extension. This detection can be overridden by other format flags.
-   **BSON Parser Module:** Introduces a new `jaq/src/bson.rs` module to encapsulate all BSON decoding logic.
-   **Dependencies:** Adds the `bson` crate as a dependency and enables the `serde_json` feature on `jaq-json` for the conversion.
-   **Testing:** Includes unit tests for the BSON parser, covering both simple documents and BSON-specific types like `ObjectId` and `DateTime`.
-   **Documentation:** The `help.txt` file has been updated to include the new flags.

### Example Usage

```sh
# Automatically detect .bson file
jaq . data.bson

# Explicitly parse BSON from stdin
cat data.bson | jaq --bson-input '.data | length'