### PR TITLE
chore: mismatched_lifetime_syntaxes

### DIFF
--- a/jaq-core/src/rc_list.rs
+++ b/jaq-core/src/rc_list.rs
@@ -71,7 +71,7 @@ impl<T> List<T> {
         cur
     }
 
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter(self)
     }
 }


### PR DESCRIPTION
warning: hiding a lifetime that's elided elsewhere is confusing
  --> jaq-core/src/rc_list.rs:74:17
   |
74 |     pub fn iter(&self) -> Iter<T> {
   |                 ^^^^^     ------- the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
74 |     pub fn iter(&self) -> Iter<'_, T> {
   |                                +++