### PR TITLE
deps: bump foldhash from 0.1 to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -19,7 +19,7 @@ parse = ["hifijson"]
 jaq-core = { version = "2.1.0", path = "../jaq-core" }
 jaq-std  = { version = "2.1.0", path = "../jaq-std" }
 
-foldhash = { version = "0.1", default-features = false }
+foldhash = { version = "0.2", default-features = false }
 hifijson = { version = "0.2.0", default-features = false, features = ["alloc"], optional = true }
 indexmap = { version = "2.0", default-features = false }
 serde_json = { version = "1.0.81", default-features = false, features = ["alloc"], optional = true }


### PR DESCRIPTION
which features faster performance for short strings - perfect for json keys...

https://github.com/orlp/foldhash/pull/35