### PR TITLE
Use a tree-like structure instead of a linked list for variables.

### DIFF
--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -5,7 +5,7 @@ use crate::compile::{Bind, Fold, Pattern, Tailrec, Term as Ast, TermId as Id};
 use crate::data::{DataT, HasLut};
 use crate::fold::fold;
 use crate::val::{ValR, ValT, ValX, ValXs};
-use crate::{exn, rc_lazy_list, Bind as Arg, Error, Exn, RcList};
+use crate::{exn, rc_lazy_list, Bind as Arg, Error, Exn, RcList, RcTree};
 use alloc::boxed::Box;
 use dyn_clone::DynClone;
 
@@ -29,16 +29,16 @@ type BoxUpdate<'a, V> = Box<dyn Update<'a, V> + 'a>;
 
 /// List of bindings.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Vars<V>(RcList<Bind<V, usize, (Id, Self)>>);
+pub struct Vars<V>(RcTree<Bind<V, usize, (Id, Self)>>);
 
 impl<V> Vars<V> {
     /// Initialise new variables from values.
     pub fn new(vars: impl IntoIterator<Item = V>) -> Self {
-        Self(RcList::new().extend(vars.into_iter().map(Bind::Var)))
+        Self(RcTree::new().extend(vars.into_iter().map(Bind::Var)))
     }
 
     fn get(&self, i: usize) -> Option<&Bind<V, usize, (Id, Self)>> {
-        self.0.get(i)
+        self.0.get(self.0.len() - i - 1)
     }
 }
 
@@ -70,26 +70,27 @@ impl<'a, D: DataT> Ctx<'a, D> {
 
     /// Add a new variable binding.
     fn cons_var(mut self, x: D::V<'a>) -> Self {
-        self.vars.0 = self.vars.0.cons(Bind::Var(x));
+        self.vars.0 = self.vars.0.push(Bind::Var(x));
         self
     }
 
     /// Add a new filter binding.
     fn cons_fun(mut self, (f, ctx): (Id, Self)) -> Self {
-        self.vars.0 = self.vars.0.cons(Bind::Fun((f, ctx.vars)));
+        self.vars.0 = self.vars.0.push(Bind::Fun((f, ctx.vars)));
         self
     }
 
     fn cons_label(mut self) -> Self {
         self.labels += 1;
-        self.vars.0 = self.vars.0.cons(Bind::Label(self.labels));
+        self.vars.0 = self.vars.0.push(Bind::Label(self.labels));
         self
     }
 
     /// Remove the `skip` most recent variable bindings.
     fn skip_vars(mut self, skip: usize) -> Self {
         if skip > 0 {
-            self.vars.0 = self.vars.0.skip(skip).clone();
+            let len = self.vars.0.len();
+            self.vars.0 = self.vars.0.truncate(len - skip);
         }
         self
     }

--- a/jaq-core/src/lib.rs
+++ b/jaq-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod ops;
 pub mod path;
 mod rc_lazy_list;
 mod rc_list;
+mod rc_tree;
 mod stack;
 pub mod val;
 
@@ -67,6 +68,7 @@ pub use filter::{Ctx, Cv, Native, PathsPtr, RunPtr, UpdatePtr, Vars};
 pub use val::{unwrap_valr, ValR, ValT, ValX, ValXs};
 
 use rc_list::List as RcList;
+use rc_tree::Root as RcTree;
 use stack::Stack;
 
 /// Argument of a definition, such as `$v` or `f` in `def foo($v; f): ...`.

--- a/jaq-core/src/rc_list.rs
+++ b/jaq-core/src/rc_list.rs
@@ -19,15 +19,6 @@ impl<T> Default for List<T> {
     }
 }
 
-impl<T: Clone> List<T> {
-    pub fn pop(self) -> Option<(T, Self)> {
-        match alloc::rc::Rc::try_unwrap(self.0).unwrap_or_else(|rc| (*rc).clone()) {
-            Node::Nil => None,
-            Node::Cons(head, tail) => Some((head, tail)),
-        }
-    }
-}
-
 impl<T> List<T> {
     /// Return an empty list.
     pub fn new() -> Self {
@@ -37,38 +28,6 @@ impl<T> List<T> {
     /// Append a new element to the list.
     pub fn cons(self, x: T) -> Self {
         Self(Node::Cons(x, self).into())
-    }
-
-    /// Repeatedly add elements to the list.
-    pub fn extend(self, iter: impl IntoIterator<Item = T>) -> Self {
-        iter.into_iter().fold(self, Self::cons)
-    }
-
-    /// Return the element most recently added to the list.
-    pub fn head(&self) -> Option<&T> {
-        match &*self.0 {
-            Node::Nil => None,
-            Node::Cons(x, _) => Some(x),
-        }
-    }
-
-    /// Get the `n`-th element from the list, starting from the most recently added.
-    pub fn get(&self, n: usize) -> Option<&T> {
-        self.skip(n).head()
-    }
-
-    /// Remove the `n` top values from the list.
-    ///
-    /// If `n` is greater than the number of list elements, return nil.
-    pub fn skip(&self, n: usize) -> &Self {
-        let mut cur = self;
-        for _ in 0..n {
-            match &*cur.0 {
-                Node::Cons(_, xs) => cur = xs,
-                Node::Nil => break,
-            }
-        }
-        cur
     }
 
     pub fn iter(&self) -> Iter<T> {
@@ -97,14 +56,4 @@ fn test() {
 
     let l = List::new().cons(2).cons(1).cons(0);
     eq(&l, vec![0, 1, 2]);
-
-    eq(l.skip(0), vec![0, 1, 2]);
-    eq(l.skip(1), vec![1, 2]);
-    eq(l.skip(2), vec![2]);
-    eq(l.skip(3), vec![]);
-
-    assert_eq!(l.get(0), Some(&0));
-    assert_eq!(l.get(1), Some(&1));
-    assert_eq!(l.get(2), Some(&2));
-    assert_eq!(l.get(3), None);
 }

--- a/jaq-core/src/rc_tree.rs
+++ b/jaq-core/src/rc_tree.rs
@@ -1,0 +1,175 @@
+use alloc::{boxed::Box, rc::Rc};
+
+/// Root of a vector tree.
+///
+/// Unlike a `Vec`, a vector tree can be cloned in O(1).
+/// Furthermore, unlike a linked list, elements can be looked up in O(log n).
+/// However, adding elements also takes O(log n).
+#[derive(Debug, PartialEq, Eq)]
+pub struct Root<T>(Option<Rc<Tree<T>>>);
+
+impl<T> Default for Root<T> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<T> Clone for Root<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> Root<T> {
+    /// Construct an empty tree.
+    pub fn new() -> Self {
+        Self(None)
+    }
+
+    /// Number of elements stored in the tree.
+    ///
+    /// Complexity: O(1)
+    pub fn len(&self) -> usize {
+        self.0.as_ref().map_or(0, |tree| tree.len())
+    }
+
+    /// Add an element to the tree.
+    ///
+    /// Complexity: O(log n)
+    pub fn push(self, x: T) -> Self {
+        match self.0 {
+            None => Self(Some(Tree::Leaf(x).into())),
+            Some(tree) => Self(Some(Tree::push(tree, x))),
+        }
+    }
+
+    /// Get the `n`-th element added to the tree.
+    ///
+    /// Complexity: O(log n)
+    pub fn get(&self, n: usize) -> Option<&T> {
+        self.0.as_ref().and_then(|tree| tree.get(n))
+    }
+
+    /// Keep only the first `n` elements in the tree.
+    ///
+    /// Complexity: O(log n)
+    pub fn truncate(self, n: usize) -> Self {
+        match n {
+            0 => Self(None),
+            n => Self(self.0.map(|tree| Tree::truncate(tree, n))),
+        }
+    }
+
+    /// Repeatedly add elements to the tree.
+    pub fn extend(self, iter: impl IntoIterator<Item = T>) -> Self {
+        iter.into_iter().fold(self, Self::push)
+    }
+
+    #[allow(dead_code)]
+    pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
+        self.0.iter().flat_map(|tree| tree.iter())
+    }
+}
+
+impl<T: Clone> Root<T> {
+    /// Remove most recently added element from the tree.
+    ///
+    /// Complexity: O(log n)
+    pub fn pop(self) -> Option<(T, Self)> {
+        self.0.and_then(|tree| {
+            let (x, tree_) = Tree::pop(tree);
+            Some((x, Self(tree_)))
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Tree<T> {
+    Node(usize, Rc<Self>, Rc<Self>),
+    Leaf(T),
+}
+
+impl<T> Tree<T> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Leaf(_) => 1,
+            Self::Node(len, ..) => *len,
+        }
+    }
+
+    fn push(tree: Rc<Self>, x: T) -> Rc<Self> {
+        let (len, l, r) = match &*tree {
+            Self::Leaf(_) => (1, tree, Self::Leaf(x).into()),
+            // tree is full
+            Self::Node(len, ..) if len.is_power_of_two() => (*len, tree, Self::Leaf(x).into()),
+            Self::Node(len, l, r) => (*len, l.clone(), Tree::push(r.clone(), x)),
+        };
+        Self::Node(len + 1, l, r).into()
+    }
+
+    fn get(&self, n: usize) -> Option<&T> {
+        match self {
+            Self::Leaf(leaf) => Some(leaf).filter(|_| n == 0),
+            Self::Node(len, l, r) => n
+                .checked_sub(len.next_power_of_two() / 2)
+                .map_or_else(|| l.get(n), |n_| r.get(n_)),
+        }
+    }
+
+    fn truncate(tree: Rc<Self>, n: usize) -> Rc<Self> {
+        debug_assert!(n > 0);
+        let cut = |l: &Rc<Self>, r: &Rc<Self>, n_| match n_ {
+            0 => l.clone(),
+            n_ => Rc::new(Self::Node(
+                l.len() + core::cmp::min(r.len(), n_),
+                l.clone(),
+                Tree::truncate(r.clone(), n_),
+            )),
+        };
+        match &*tree {
+            Self::Leaf(_) => tree,
+            Self::Node(len, l, r) => n
+                .checked_sub(len.next_power_of_two() / 2)
+                .map_or_else(|| Tree::truncate(l.clone(), n), |n_| cut(l, r, n_)),
+        }
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = &T> + '_> {
+        match self {
+            Self::Leaf(leaf) => Box::new(core::iter::once(leaf)),
+            Self::Node(_, l, r) => Box::new(l.iter().chain(r.iter())),
+        }
+    }
+}
+
+impl<T: Clone> Tree<T> {
+    fn pop(tree: Rc<Self>) -> (T, Option<Rc<Self>>) {
+        match &*tree {
+            Self::Leaf(leaf) => (leaf.clone(), None),
+            Self::Node(len, l, r) => match Tree::pop(r.clone()) {
+                (x, None) => (x, Some(l.clone())),
+                (x, Some(r_)) => (x, Some(Self::Node(len - 1, l.clone(), r_).into())),
+            },
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use alloc::{vec, vec::Vec};
+    let eq = |l: &Root<_>, a| assert_eq!(l.iter().cloned().collect::<Vec<_>>(), a);
+
+    let l = Root::new().push(0).push(1).push(2);
+    eq(&l, vec![0, 1, 2]);
+
+    eq(&l.clone().truncate(4), vec![0, 1, 2]);
+    eq(&l.clone().truncate(3), vec![0, 1, 2]);
+    eq(&l.clone().truncate(2), vec![0, 1]);
+    eq(&l.clone().truncate(1), vec![0]);
+    eq(&l.clone().truncate(0), vec![]);
+
+    assert_eq!(l.get(0), Some(&0));
+    assert_eq!(l.get(1), Some(&1));
+    assert_eq!(l.get(2), Some(&2));
+    assert_eq!(l.get(3), None);
+}

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloc::{borrow::ToOwned, format, string::ToString};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt::{self, Debug, Display, Formatter};
-use jaq_core::{compile, data, load, unwrap_valr, Ctx, DataT, Native, Lut, Vars};
+use jaq_core::{compile, data, load, unwrap_valr, Ctx, DataT, Lut, Native, Vars};
 use jaq_json::{fmt_str, Val};
 use jaq_std::input::{self, HasInputs, Inputs, RcIter};
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
This improves the complexity of variable lookup    from O(n) to O(log n), but
deteriorates  the complexity of variable insertion from O(1) to O(log n).

If the current O(n) complexity for variable lookup should turn out to be a bottleneck some day, this PR is the way to go.