### PR TITLE
Remove raw strings

### DIFF
--- a/jaq-json/src/cbor.rs
+++ b/jaq-json/src/cbor.rs
@@ -234,7 +234,6 @@ fn encode<W: Write>(v: &Val, encoder: &mut Encoder<W>) -> Result<(), W::Error> {
         Val::Num(Num::Dec(d)) => encode(&Val::Num(Num::from_dec_str(d)), encoder),
         Val::Str(s, Tag::Utf8) => encoder.text(&String::from_utf8_lossy(s), None),
         Val::Str(b, Tag::Bytes) => encoder.bytes(b, None),
-        Val::Str(b, Tag::Raw) => encoder.write_all(b),
         Val::Arr(a) => {
             encoder.push(Header::Array(Some(a.len())))?;
             a.iter().try_for_each(|x| encode(x, encoder))

--- a/jaq-json/src/funs.rs
+++ b/jaq-json/src/funs.rs
@@ -1,5 +1,5 @@
 use crate::{Error, Num, Tag, Val, ValR, ValX};
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use bstr::ByteSlice;
 use bytes::{BufMut, Bytes, BytesMut};
 use jaq_core::box_iter::{box_once, BoxIter};
@@ -16,7 +16,7 @@ impl Val {
             Val::Null => Ok(Val::from(0usize)),
             Val::Num(n) => Ok(Val::Num(n.length())),
             Val::Str(s, Tag::Utf8) => Ok(Val::from(s.chars().count() as isize)),
-            Val::Str(b, Tag::Bytes | Tag::Raw) => Ok(Val::from(b.len() as isize)),
+            Val::Str(b, Tag::Bytes) => Ok(Val::from(b.len() as isize)),
             Val::Arr(a) => Ok(Val::from(a.len() as isize)),
             Val::Obj(o) => Ok(Val::from(o.len() as isize)),
             Val::Bool(_) => Err(Error::str(format_args!("{self} has no length"))),
@@ -130,12 +130,6 @@ fn base<D: for<'a> DataT<V<'a> = Val>>() -> Box<[Filter<RunPtr<D>>]> {
             let pass = |b| Val::Str(b, Tag::Bytes);
             let fail = |v| Error::str(format_args!("cannot convert {v} to bytes"));
             bome(cv.1.to_bytes().map(pass).map_err(fail))
-        }),
-        ("torawstring", v(0), |cv| {
-            box_once(Ok(match cv.1 {
-                Val::Str(s, _) => Val::Str(s, Tag::Raw),
-                v => Val::Str(v.to_string().into(), Tag::Raw),
-            }))
         }),
         ("length", v(0), |cv| bome(cv.1.length())),
         ("contains", v(1), |cv| {

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -73,8 +73,6 @@ pub enum Val {
 /// as well as how a string is printed.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Tag {
-    /// Sequence of bytes, not to be escaped
-    Raw,
     /// Sequence of bytes, to be escaped
     Bytes,
     /// Sequence of UTF-8 code points

--- a/jaq-json/src/serde_json.rs
+++ b/jaq-json/src/serde_json.rs
@@ -1,7 +1,6 @@
 //! [`serde_json::Value`] support.
 use crate::{Num, Tag, Val};
 use alloc::string::ToString;
-use bytes::Bytes;
 use jaq_std::ValT;
 
 impl From<serde_json::Value> for Val {
@@ -24,8 +23,6 @@ pub enum SError {
     Num(Num),
     /// Non-string key in object
     Key(Val),
-    /// Raw string
-    Raw(Bytes),
 }
 
 fn from_key(k: &Val) -> Result<&[u8], SError> {
@@ -48,7 +45,6 @@ impl TryFrom<&Val> for serde_json::Value {
             ),
             Val::Str(s, Tag::Utf8) => String(from_utf8(&*s)),
             Val::Str(s, Tag::Bytes) => String(s.iter().copied().map(char::from).collect()),
-            Val::Str(s, Tag::Raw) => Err(SError::Raw(s.clone()))?,
             Val::Arr(a) => Array(a.iter().map(TryInto::try_into).collect::<Result<_, _>>()?),
             Val::Obj(o) => Object(
                 o.iter()

--- a/jaq-json/src/toml.rs
+++ b/jaq-json/src/toml.rs
@@ -128,7 +128,7 @@ fn val_item(v: &Val) -> Result<Item, SError> {
 fn val_value(v: &Val) -> Result<Value, SError> {
     let fail = || SError::Val(v.clone());
     Ok(match v {
-        Val::Null | Val::Str(_, Tag::Bytes | Tag::Raw) => Err(fail())?,
+        Val::Null | Val::Str(_, Tag::Bytes) => Err(fail())?,
         Val::Bool(b) => Value::Boolean(Formatted::new(*b)),
         Val::Str(s, Tag::Utf8) => {
             Value::String(Formatted::new(String::from_utf8_lossy(s).into_owned()))

--- a/jaq-json/src/write.rs
+++ b/jaq-json/src/write.rs
@@ -92,7 +92,6 @@ macro_rules! write_val {
             Val::Null => write!($w, "null"),
             Val::Bool(b) => write!($w, "{b}"),
             Val::Num(n) => write!($w, "{n}"),
-            Val::Str(s, Tag::Raw) => write!($w, "{}", bstr(s)),
             Val::Str(b, Tag::Bytes) => write_bytes!($w, b),
             Val::Str(s, Tag::Utf8) => write_utf8!($w, s, |part| write!($w, "{}", bstr(part))),
             Val::Arr(a) => {
@@ -126,7 +125,6 @@ type FormatFn<T> = fn(&mut Formatter, &T) -> fmt::Result;
 
 pub(crate) fn write_with(w: &mut dyn Write, v: &Val, f: WriteFn<Val>) -> io::Result<()> {
     match v {
-        Val::Str(s, Tag::Raw) => w.write_all(s),
         Val::Str(b, Tag::Bytes) => write_bytes!(w, b),
         Val::Str(s, Tag::Utf8) => write_utf8!(w, s, |part| w.write_all(part)),
         _ => write_val!(w, v, |v: &Val| f(w, v)),

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -87,7 +87,6 @@ fn fmt_val(f: &mut Formatter, opts: &PpOpts, level: usize, v: &Val) -> fmt::Resu
         Val::Null => span(f, "null", "null"),
         Val::Bool(b) => span(f, "boolean", b),
         Val::Num(n) => span(f, "number", n),
-        Val::Str(s, Tag::Raw) => write!(f, "{}", bstr(&escape_bytes(s))),
         Val::Str(b, Tag::Bytes) => {
             let fun = FormatterFn(move |f: &mut Formatter| write_bytes!(f, b));
             span(f, "bytes", escape_str(&fun.to_string()))

--- a/jaq/src/write.rs
+++ b/jaq/src/write.rs
@@ -74,7 +74,6 @@ fn write_rec(w: &mut dyn Write, pp: &Pp, level: usize, v: &Val, rec: WriteFn) ->
             write_utf8!(w, s, |part| w.write_all(part))
         }),
         Val::Str(b, Tag::Bytes) => style.write(w, style.red, |w| write_bytes!(w, b)),
-        Val::Str(s, Tag::Raw) => w.write_all(s),
         Val::Arr(a) => {
             bold(w, '[')?;
             if !a.is_empty() {


### PR DESCRIPTION
Raw strings are the only values that cannot be round-tripped. Because #327 adds the possibility to completely round-trip arbitrary values (except for raw strings), it feels cleaner to remove them, in order to have greater guarantees.