### PR TITLE
Avoid allocation when parsing negative decimal numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "hifijson"
 version = "0.2.3"
-source = "git+https://github.com/01mf02/hifijson#97358a348d28e77dd7a99f703bae029dcdc6315c"
+source = "git+https://github.com/01mf02/hifijson#038411bba398ea5ed128f4dd48f4dc8c9efe9a32"
 
 [[package]]
 name = "iana-time-zone"

--- a/jaq-json/src/json.rs
+++ b/jaq-json/src/json.rs
@@ -60,8 +60,8 @@ fn parse_string<L: LexAlloc>(lexer: &mut L, tag: Tag) -> Result<Vec<u8>, hifijso
     s.map_err(hifijson::Error::Str)
 }
 
-fn parse_num<L: LexAlloc>(lexer: &mut L) -> Result<Num, hifijson::Error> {
-    let (num, parts) = lexer.num_string()?;
+fn parse_num<L: LexAlloc>(lexer: &mut L, prefix: &str) -> Result<Num, hifijson::Error> {
+    let (num, parts) = lexer.num_string(prefix)?;
     // if we are dealing with an integer ...
     Ok(if parts.dot.is_none() && parts.exp.is_none() {
         Num::try_from_int_str(&num, 10).unwrap()
@@ -90,9 +90,9 @@ fn parse<L: LexAlloc>(token: Token, lexer: &mut L) -> Result<Val, hifijson::Erro
         Token::Minus => Val::Num(match lexer.peek_next() {
             Some(b'I') if lexer.strip_prefix(b"Infinity") => Num::Float(f64::NEG_INFINITY),
             Some(b'I') => Err(Expect::Value)?,
-            _ => -parse_num(lexer)?,
+            _ => parse_num(lexer, "-")?,
         }),
-        Token::Other(b'0'..=b'9') => Val::Num(parse_num(lexer)?),
+        Token::Other(b'0'..=b'9') => Val::Num(parse_num(lexer, "")?),
         Token::Quote => Val::utf8_str(parse_string(lexer, Tag::Utf8)?),
         Token::LSquare => Val::Arr({
             let mut arr = Vec::new();

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -347,7 +347,7 @@ impl jaq_std::ValT for Val {
 
     fn as_f64(&self) -> Result<f64, Error> {
         let fail = || Error::typ(self.clone(), Type::Float.as_str());
-        self.as_num().and_then(Num::as_f64).ok_or_else(fail)
+        self.as_num().map(Num::as_f64).ok_or_else(fail)
     }
 
     fn is_utf8_str(&self) -> bool {

--- a/jaq-json/src/num.rs
+++ b/jaq-json/src/num.rs
@@ -82,12 +82,12 @@ impl Num {
     }
 
     /// If the value is or can be converted to float, return it, else fail.
-    pub(crate) fn as_f64(&self) -> Option<f64> {
+    pub(crate) fn as_f64(&self) -> f64 {
         match self {
-            Self::Int(n) => Some(*n as f64),
-            Self::BigInt(n) => Some(n.to_f64().unwrap()),
-            Self::Float(n) => Some(*n),
-            Self::Dec(n) => n.parse().ok(),
+            Self::Int(n) => *n as f64,
+            Self::BigInt(n) => n.to_f64().unwrap(),
+            Self::Float(n) => *n,
+            Self::Dec(n) => n.parse().unwrap(),
         }
     }
 


### PR DESCRIPTION
This PR uses a new feature of `hifijson` to simplify and speed up parsing of negative decimal numbers.

Negating a `jaq_json::Num::Dec(_)` is relatively costly, because it allocates a new string and a new `Rc` pointer. Since #327, jaq performed such a negation whenever a negative decimal number was parsed. Now, parsing does not rely on negating an existing `Num`, but creates the correct `Num` from the start.