### PR TITLE
Simplify type of `as_f64` and introduce `try_as_f64`

### DIFF
--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -101,8 +101,10 @@ pub enum Tag {
 enum Type {
     /// `[] | .["a"]` or `limit("a"; 0)` or `range(0; "a")`
     Int,
+    /*
     /// `"1" | sin` or `pow(2; "3")` or `fma(2; 3; "4")`
     Float,
+    */
     /// `-"a"`, `"a" | round`
     Num,
     /*
@@ -121,7 +123,7 @@ impl Type {
     fn as_str(&self) -> &'static str {
         match self {
             Self::Int => "integer",
-            Self::Float => "floating-point number",
+            //Self::Float => "floating-point number",
             Self::Num => "number",
             //Self::Str => "string",
             Self::Arr => "array",
@@ -345,9 +347,8 @@ impl jaq_std::ValT for Val {
         self.as_num().and_then(Num::as_isize)
     }
 
-    fn as_f64(&self) -> Result<f64, Error> {
-        let fail = || Error::typ(self.clone(), Type::Float.as_str());
-        self.as_num().map(Num::as_f64).ok_or_else(fail)
+    fn as_f64(&self) -> Option<f64> {
+        self.as_num().map(Num::as_f64)
     }
 
     fn is_utf8_str(&self) -> bool {

--- a/jaq-std/src/math.rs
+++ b/jaq-std/src/math.rs
@@ -38,21 +38,21 @@ pub(crate) use math;
 /// Build a filter from float to float
 macro_rules! f_f {
     ($f: ident) => {
-        crate::math::math!($f, D::V::as_f64, D::V::from)
+        crate::math::math!($f, D::V::try_as_f64, D::V::from)
     };
 }
 
 /// Build a filter from float to int
 macro_rules! f_i {
     ($f: ident) => {
-        crate::math::math!($f, D::V::as_f64, |x| D::V::from(x as isize))
+        crate::math::math!($f, D::V::try_as_f64, |x| D::V::from(x as isize))
     };
 }
 
 /// Build a filter from float to (float, int)
 macro_rules! f_fi {
     ($f: ident) => {
-        crate::math::math!($f, D::V::as_f64, |(x, y)| [
+        crate::math::math!($f, D::V::try_as_f64, |(x, y)| [
             D::V::from(x),
             D::V::from(y as isize)
         ]
@@ -64,37 +64,46 @@ macro_rules! f_fi {
 /// Build a filter from float to (float, float)
 macro_rules! f_ff {
     ($f: ident) => {
-        crate::math::math!($f, D::V::as_f64, |(x, y)| [D::V::from(x), D::V::from(y)]
-            .into_iter()
-            .collect())
+        crate::math::math!($f, D::V::try_as_f64, |(x, y)| [
+            D::V::from(x),
+            D::V::from(y)
+        ]
+        .into_iter()
+        .collect())
     };
 }
 
 /// Build a filter from (float, float) to float
 macro_rules! ff_f {
     ($f: ident) => {
-        crate::math::math!($f, D::V::as_f64, D::V::as_f64, D::V::from)
+        crate::math::math!($f, D::V::try_as_f64, D::V::try_as_f64, D::V::from)
     };
 }
 
 /// Build a filter from (int, float) to float
 macro_rules! if_f {
     ($f: ident) => {
-        crate::math::math!($f, D::V::try_as_i32, D::V::as_f64, D::V::from)
+        crate::math::math!($f, D::V::try_as_i32, D::V::try_as_f64, D::V::from)
     };
 }
 
 /// Build a filter from (float, int) to float
 macro_rules! fi_f {
     ($f: ident) => {
-        crate::math::math!($f, D::V::as_f64, D::V::try_as_i32, D::V::from)
+        crate::math::math!($f, D::V::try_as_f64, D::V::try_as_i32, D::V::from)
     };
 }
 
 /// Build a filter from (float, float, float) to float
 macro_rules! fff_f {
     ($f: ident) => {
-        crate::math::math!($f, D::V::as_f64, D::V::as_f64, D::V::as_f64, D::V::from)
+        crate::math::math!(
+            $f,
+            D::V::try_as_f64,
+            D::V::try_as_f64,
+            D::V::try_as_f64,
+            D::V::from
+        )
     };
 }
 


### PR DESCRIPTION
This makes it clear that `as_f64` can fail in only one way, namely if a value is not a number.