### PR TITLE
Delete `Default` implementation for `Lut`

### DIFF
--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -32,15 +32,6 @@ pub struct Lut<F> {
     pub(crate) funs: Vec<F>,
 }
 
-impl<F> Default for Lut<F> {
-    fn default() -> Self {
-        Lut {
-            terms: Vec::new(),
-            funs: Vec::new(),
-        }
-    }
-}
-
 impl<F> Default for Filter<F> {
     fn default() -> Self {
         Self {
@@ -230,7 +221,10 @@ pub struct Compiler<S, F> {
 impl<S, F> Default for Compiler<S, F> {
     fn default() -> Self {
         Self {
-            lut: Lut::default(),
+            lut: Lut {
+                terms: Vec::new(),
+                funs: Vec::new(),
+            },
             mod_map: Vec::new(),
             imported_mods: Vec::new(),
             included_mods: Vec::new(),

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -3,9 +3,9 @@ mod filter;
 mod funs;
 mod read;
 mod style;
-mod write;
 #[cfg(target_os = "windows")]
 mod windows;
+mod write;
 
 use cli::{Cli, Format};
 use core::fmt::{self, Display, Formatter};


### PR DESCRIPTION
This removal is intended to resolve unintentional crashes as observed in https://github.com/01mf02/jaq/issues/323#issuecomment-3333517132.