### PR TITLE
Make `null.[$x]` return `null` for any `$x`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,11 +554,6 @@ The interpretation of `reduce`/`foreach` in jaq has the following advantages ove
   In jq, `[(1,2) * (3,4)]` yields `[3, 6, 4, 8]`, whereas
   `[{a: (1,2), b: (3,4)} | .a * .b]` yields `[3, 4, 6, 8]`.
   jaq yields `[3, 4, 6, 8]` in both cases.
-* Indexing `null`:
-  In jq, when given `null` input, `.["a"]` and `.[0]` yield `null`, but `.[]` yields an error.
-  jaq yields an error in all cases to prevent accidental indexing of `null` values.
-  To obtain the same behaviour in jq and jaq, you can use
-  `.["a"]? // null` or `.[0]? // null` instead.
 * List updating:
   In jq, `[0, 1] | .[3] = 3` yields `[0, 1, null, 3]`; that is,
   jq fills up the list with `null`s if we update beyond its size.

--- a/jaq-core/tests/path.rs
+++ b/jaq-core/tests/path.rs
@@ -81,6 +81,12 @@ yields!(obj_keyword, "{if: 0} | .if", 0);
 yields!(key_update1, "{} | .a  |= .+1", json!({"a": 1}));
 yields!(key_update2, "{} | .a? |= .+1", json!({"a": 1}));
 
+yields!(null_index1, ".a", json!(null));
+yields!(null_index2, ".[0]", json!(null));
+
+yields!(null_update1, ".a |= .+1", json!({"a": 1}));
+yields!(null_update2, "(.[0] |= .+1) == {(0): 1}", true);
+
 // `.[f]?` is *not* the same as `(.[f])?`
 // (we're writing `0[]` to simulate `error` here)
 yields!(index_opt_inner, "try .[0[]]? catch 1", 1);

--- a/jaq-core/tests/path.rs
+++ b/jaq-core/tests/path.rs
@@ -84,9 +84,6 @@ yields!(key_update2, "{} | .a? |= .+1", json!({"a": 1}));
 yields!(null_index1, ".a", json!(null));
 yields!(null_index2, ".[0]", json!(null));
 
-yields!(null_update1, ".a |= .+1", json!({"a": 1}));
-yields!(null_update2, "(.[0] |= .+1) == {(0): 1}", true);
-
 // `.[f]?` is *not* the same as `(.[f])?`
 // (we're writing `0[]` to simulate `error` here)
 yields!(index_opt_inner, "try .[0[]]? catch 1", 1);

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -178,6 +178,7 @@ impl jaq_core::ValT for Val {
 
     fn index(self, index: &Self) -> ValR {
         match (self, index) {
+            (Val::Null, _) => Ok(Val::Null),
             (Val::Str(a, Tag::Bytes), Val::Num(i @ (Num::Int(_) | Num::BigInt(_)))) => Ok(i
                 .as_pos_usize()
                 .and_then(|i| abs_index(i, a.len()))
@@ -244,6 +245,7 @@ impl jaq_core::ValT for Val {
         f: impl Fn(Self) -> I,
     ) -> ValX {
         match self {
+            Val::Null => Val::Obj(Default::default()).map_index(index, opt, f),
             Val::Obj(ref mut o) => {
                 use indexmap::map::Entry::{Occupied, Vacant};
                 let o = Rc::make_mut(o);

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -245,7 +245,6 @@ impl jaq_core::ValT for Val {
         f: impl Fn(Self) -> I,
     ) -> ValX {
         match self {
-            Val::Null => Val::Obj(Default::default()).map_index(index, opt, f),
             Val::Obj(ref mut o) => {
                 use indexmap::map::Entry::{Occupied, Vacant};
                 let o = Rc::make_mut(o);


### PR DESCRIPTION
Over the years, there have been many issues (#19, #208, #272, #275, #313) because `null[$x]` yields an error in jaq, but returns `null` in jq.

Recent changes in another part of jaq have led me to revise this design decision. In particular, before the introduction of byte strings, it was true that for any type of values, if you could index them, then you could also iterate over them. To have that property, it followed that `null` could not be indexed, because it cannot be iterated over. However, byte strings can also be indexed, yet not iterated over.

This PR now makes indexing `null` in jaq always return `null`, like in jq.
However, it still preserves the behaviour that updating `null` at any index fails. The reason for this is that this might introduce pretty subtle bugs when running code like `null | .[0] = 1`. In jq, that would yield `[1]`, but in jaq, this might equally well yield `{(0): 1}`, because jaq now supports non-string object keys. To prevent that confusion, we better throw an error.
This is similar to byte strings, which also allows indexing, but not updating at an index.