### PR TITLE
Make `byteoffset` take two arguments.

### DIFF
--- a/examples/tar.jq
+++ b/examples/tar.jq
@@ -15,7 +15,7 @@
 # this decoder stores *where* that data came from.
 # That means that we can obtain e.g. the byte offset of each file header:
 #
-# . as $i | decode_tar | {name: .o.name, offset: .i | byteoffset($i)}
+#     . as $i | decode_tar | {name: .o.name, offset: byteoffset(.i; $i)}
 #
 # All these commands take about 200 milliseconds on my machine.
 # For comparison, `tar --list --file 1G.tar` takes about 10 milliseconds.
@@ -86,8 +86,7 @@ def decode_entry:
   . as $input |
   # we use i as remaining input, which we later use to infer consumed input
   {i: .} |
-  # TODO: make byteoffset fail
-  def consumed: .i | byteoffset($input) // error;
+  def consumed: byteoffset(.i; $input);
   def offset: (BLOCK_BYTES - (consumed % BLOCK_BYTES)) % BLOCK_BYTES;
   str("name"; 100) |
   oct("mode"; 8) |
@@ -104,7 +103,7 @@ def decode_entry:
 ;
 
 # Translate from i denoting remaining input to i denoting consumed input.
-def set_consumed($input): .i |= .[:byteoffset($input)];
+def set_consumed($input): .i |= .[:byteoffset(.; $input)];
 
 def decode_tar: tobytes |
   ([limit(BLOCK_BYTES*2; repeat(0))] | tobytes) as $END_MARKER |

--- a/jaq-json/tests/funs.rs
+++ b/jaq-json/tests/funs.rs
@@ -10,9 +10,9 @@ yields!(bsearch_absent2, "[1, 3] | bsearch(2)", -2);
 yields!(bsearch_absent3, "[1, 3] | bsearch(4)", -3);
 yields!(bsearch_present, "[1, 3] | [bsearch(1, 3)]", [0, 1]);
 
-yields!(byteoff1, r#""asd" as $x | $x[1:] | byteoffset($x)  "#, 1);
-yields!(byteoff2, r#""asd" as $x | "df" | byteoffset($x)? // 9"#, 9);
-yields!(byteoff3, r#""asd" as $x | $x | byteoffset($x[1:])"#, -1);
+yields!(byteoff1, r#""asd" | byteoffset(.[1:]; .)"#, 1);
+yields!(byteoff2, r#""asd" | byteoffset(.; .[1:])"#, -1);
+yields!(byteoff3, r#""asd" | byteoffset("df"; .)? // 9"#, 9);
 
 // 41 = 0x29
 yields!(fromcbor1, "[41] | tobytes | fromcbor", -10);

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -495,8 +495,8 @@ where
         ("ascii_upcase", v(0), |cv| {
             bome(cv.1.map_utf8_str(ByteSlice::to_ascii_uppercase))
         }),
-        ("byteoffset", v(1), |mut cv| {
-            bome(byte_offset(cv.0.pop_var(), cv.1))
+        ("byteoffset", v(2), |mut cv| {
+            bome(byte_offset(cv.0.pop_var(), cv.0.pop_var()))
         }),
         ("reverse", v(0), |cv| bome(cv.1.mutate_arr(|a| a.reverse()))),
         ("keys_unsorted", v(0), |cv| {


### PR DESCRIPTION
This makes the usage of `byteoffset` (hopefully) more ergonomic and easier to remember.
Now, `byteoffset($x; $y)` calculates $o_x - o_y$, where $o_x$ and $o_y$ are the (byte) addresses of `$x` and `$y` in memory, respectively.
That means that `byteoffset/2` now looks more like a subtraction operation, which it actually also is.