### PR TITLE
Use `regex` instead of `regex-lite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "jaq-json",
  "libm",
  "log",
+ "regex-automata",
  "regex-lite",
  "serde_json",
  "urlencoding",
@@ -599,14 +600,25 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-lite"
 version = "0.1.6"
 source = "git+https://github.com/01mf02/regex?branch=bytes#cd695a8ad0bfc6331fbdeae8ae1b2630595767ce"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustix"

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -30,6 +30,7 @@ libm = { version = "0.2.7", optional = true }
 aho-corasick = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true }
 urlencoding = { version = "2.1.3", optional = true }
+regex-automata = "0.4.13"
 
 [dev-dependencies]
 jaq-json = { path = "../jaq-json" }


### PR DESCRIPTION
This is an experiment, see [#1274](https://github.com/rust-lang/regex/pull/1274).

I evaluated jqjq with it as follows:

~~~
cd jaq
cargo build --release
git clone https://github.com/wader/jqjq
cd jqjq
git checkout 535076f3c4ede19817d5946a6d1703b04d18778a
time ../target/release/jaq -n -L . 'include "jqjq"; eval(".")'
~~~

This yields 0.921s with `regex` + PikeVM vs. 0.493s with `regex_lite`.
(For comparison, jq takes 0.499s.)