### PR TITLE
Make `jaq_json::Map` public

### DIFF
--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -134,7 +134,7 @@ impl Type {
 }
 
 /// Order-preserving map
-type Map<K = Val, V = K> = indexmap::IndexMap<K, V, foldhash::fast::RandomState>;
+pub type Map<K = Val, V = K> = indexmap::IndexMap<K, V, foldhash::fast::RandomState>;
 
 /// Error that can occur during filter execution.
 pub type Error = jaq_core::Error<Val>;


### PR DESCRIPTION
~~This makes some of the `as_x` accessors on `Value` and `Num` public, I've found them to be useful working on https://github.com/jakobhellermann/uniscan and thing it would be a good thing to have available as a user of the library.~~

EDIT: Just make `jaq_json::Map` public. It's useful when you want to construct a new object.