### PR TITLE
Implement `skip` natively.

### DIFF
--- a/jaq-json/src/num.rs
+++ b/jaq-json/src/num.rs
@@ -267,7 +267,7 @@ impl Hash for Num {
                     state.write_u8(1);
                     i.hash(state)
                 }
-            },
+            }
         }
     }
 }

--- a/jaq-std/src/defs.jq
+++ b/jaq-std/src/defs.jq
@@ -102,8 +102,7 @@ def first:  .[ 0];
 def last:   .[-1];
 def nth(n): .[ n];
 
-def skip($n; g): foreach g as $x ($n; . - 1; if . < 0 then $x else empty end);
-def nth(n; g): last(limit(n + 1; g));
+def nth(n; g): first(skip(n; g));
 
 # Objects <-> Arrays
 def keys: keys_unsorted | sort;

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -165,6 +165,9 @@ fn limit() {
 
 yields!(limit_overflow, "[limit(0; def f: f | .; f)]", json!([]));
 
+yields!(limit_path, "[1, 2, 3] | [path(limit(2; .[]))]", [[0], [1]]);
+yields!(skip_path, "[1, 2, 3] | [path(skip(1; .[]))]", [[1], [2]]);
+
 yields!(
     math_0_argument_scalar_filters,
     "[-2.2, -1.1, 0, 1.1, 2.2 | sin as $s | cos as $c | $s * $s + $c * $c]",


### PR DESCRIPTION
This allows using `skip` and `nth` as a path expression.
Furthermore, it also makes `nth($n; f)` return no output if `$n` exceeds the number of elements output by `f`.