### PR TITLE
Switch to upstream version of `hifijson` and to `regex-bites`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,8 +263,9 @@ dependencies = [
 
 [[package]]
 name = "hifijson"
-version = "0.2.3"
-source = "git+https://github.com/01mf02/hifijson#da80bf1d2dc3a001d54d32b848faff18bafd2f5d"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfe2fde708376d2a8da67b6cb2385a3b86bbe8ef43e3076e954b9c6ffa89ff3"
 
 [[package]]
 name = "indexmap"
@@ -365,13 +366,12 @@ dependencies = [
  "aho-corasick",
  "base64",
  "bstr",
- "hifijson",
  "jaq-core",
  "jaq-json",
  "jiff",
  "libm",
  "log",
- "regex-lite",
+ "regex-bites",
  "serde_json",
  "urlencoding",
 ]
@@ -603,9 +603,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 
 [[package]]
-name = "regex-lite"
+name = "regex-bites"
 version = "0.1.6"
-source = "git+https://github.com/01mf02/regex?branch=bytes#cd695a8ad0bfc6331fbdeae8ae1b2630595767ce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,3 @@ resolver = "2"
 [profile.release]
 strip = true
 codegen-units = 1
-
-[patch.crates-io]
-regex-lite = { git = 'https://github.com/01mf02/regex', package = 'regex-lite', branch = 'bytes' }
-hifijson = { git = "https://github.com/01mf02/hifijson" }

--- a/jaq-core/fuzz/Cargo.toml
+++ b/jaq-core/fuzz/Cargo.toml
@@ -38,7 +38,3 @@ name = "parse_tokens"
 path = "fuzz_targets/parse_tokens.rs"
 test = false
 doc = false
-
-[patch.crates-io]
-regex-lite = { git = 'https://github.com/01mf02/regex', package = 'regex-lite', branch = 'bytes' }
-hifijson = { git = "https://github.com/01mf02/hifijson" }

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = { version = "1.0.81", default-features = false, features = ["alloc"
 base64 = { version = "0.22", optional = true }
 ciborium-io = { version = "0.2.2", optional = true, features = ["std"] }
 ciborium-ll = { version = "0.2.2", optional = true }
-hifijson = { version = "0.2.0", default-features = false, features = ["alloc", "std"], optional = true }
+hifijson = { version = "0.3.0", default-features = false, features = ["alloc", "std"], optional = true }
 saphyr-parser = { version = "0.0.6", optional = true }
 toml_edit = { version = "0.23.2", optional = true }
 xmlparser = { version = "0.13.6", optional = true }

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.70"
 
 [features]
 default = ["std", "format", "log", "math", "regex", "time"]
-regex = ["regex-lite"]
+regex = ["regex-bites"]
 std = []
 format = ["aho-corasick", "base64", "urlencoding"]
 math = ["libm"]
@@ -22,9 +22,8 @@ time = ["jiff"]
 jaq-core = { version = "2.1.0", path = "../jaq-core" }
 
 bstr = "1"
-hifijson = { version = "0.2.0", optional = true }
 jiff = { version = "0.2.15", optional = true }
-regex-lite = { version = "0.1", optional = true }
+regex-bites = { version = "0.1", optional = true }
 log = { version = "0.4.17", optional = true }
 libm = { version = "0.2.7", optional = true }
 aho-corasick = { version = "1.0", optional = true }

--- a/jaq-std/src/regex.rs
+++ b/jaq-std/src/regex.rs
@@ -3,7 +3,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use bstr::ByteSlice;
-use regex_lite::bytes::{self as regex, Error, Regex, RegexBuilder};
+use regex_bites::bytes::{self as regex, Error, Regex, RegexBuilder};
 
 #[derive(Copy, Clone, Default)]
 pub struct Flags {


### PR DESCRIPTION
This makes it finally possible again to publish jaq on crates.io.