### PR TITLE
Slice strings/arrays when indexing with objects.

### DIFF
--- a/jaq-std/src/defs.jq
+++ b/jaq-std/src/defs.jq
@@ -100,14 +100,7 @@ def unique: unique_by(.);
 # Paths
 def paths:    skip(1; path      (..));
 def paths(p): skip(1; path_value(..)) | if .[1] | p then .[0] else empty end;
-def getpath($path): reduce $path[] as $p (.;
-  def slice($s; $e):
-    if   $s and $e then .[$s:$e]
-    elif $s        then .[$s:]
-    elif $e        then .[  :$e]
-    else error("slice object must contain either start or end") end;
-  if . < {} and $p >= {} then slice($p.start; $p.end) else .[$p] end
-);
+def getpath($path): reduce $path[] as $p (.; .[$p]);
 def setpath($path; $x): getpath($path) = $x;
 def delpaths($paths): reduce $paths[] as $path (.; getpath($path) |= empty);
 def pick(f):


### PR DESCRIPTION
This PR enables slicing via indexing with `{start, end}` objects. For example:

- `[1, 2, 3] | .[{start: 1}] --> [2, 3]`
- `[1, 2, 3] | .[{end: -1}] --> [1, 2]`
- `[1, 2, 3] | .[{start: 1, end: -1}] --> [2]`

Furthermore, this also allows using `null` as argument to the slicing operator:

- `[1, 2, 3] | .[1:null] --> [2, 3]`
- `[1, 2, 3] | .[null:-1] --> [1, 2]`
- `[1, 2, 3] | .[null:null] --> [1, 2, 3]`

This is currently a bit more permissive than `jq`, because indexing an array with _any_ object yields the original array; i.e. `[1, 2, 3] | .[{}] --> [1, 2, 3]`. That is because an empty array is interpreted as `{start: null, end: null}`. Here, jq throws an error.

This should close #367.