### PR TITLE
Add `input_filename` support

### DIFF
--- a/docs/stdlib.dj
+++ b/docs/stdlib.dj
@@ -2264,35 +2264,21 @@ $ MYFLAG=42 jaq -n '$ENV.MYFLAG'
 
 The filter `env` is equivalent to `$ENV`.
 
-### `input_filename`, `$input_filename`
+### `input_filename`
 
-The filter `input_filename` returns:
+The filter `input_filename` returns
+the name of the file currently read, or
+`"<stdin>"` if standard input is currently read.
+If `--null-input` is used, this filter returns `null` instead.
 
-- The name of the file whose input is currently being filtered;
-- `"<stdin>"` when filtering data on standard input;
-- Or `null` if the data source is unknown (such as when using `--null-input`).
-
-This filter is implemented on top of the `$input_filename` variable, which gets set by the CLI automatically.
-
-Note that the CLI will only set the variable if it has not been explicitly set on the command line; for example,
-`jaq 'input_filename' ./data.json` will output `"./data.json"`, but
-`jaq --argjson input_filename 123 'input_filename' ./data.json` will output `123` instead.
-
-::: Compatibility
-`jq`'s version of the `input_filename/0` filter returns `"<stdin>"` when filtering data on standard input. While this
-behaviour has been preserved for `jaq`'s `input_filename/0` filter, the filter alone thus cannot be used to
-differentiate between filtering on standard input and filtering a file called `<stdin>`.
-
-To work around this, the `jaq` CLI sets the `$input_filename` variable to the actual input source: the path (if known),
-the _empty string_ for filtering data on standard input, or `null` if the data source is unknown. If your script needs
-to be able to distinguish between filtering data on standard input and filtering a file called `<stdin>`, use the
-variable rather than the filter.
-:::
-
-::: Advanced
-This filter and variable are only defined in the CLI, so are unavailable if you are using the `jaq-*` crates directly
-from Rust code.
-:::
+```
+$ jaq --slurp 'input_filename' "examples/benches.json"
+"examples/benches.json"
+$ echo 0 | jaq 'input_filename'
+"<stdin>"
+$ jaq -n 'input_filename'
+null
+```
 
 ### `repl`
 

--- a/docs/stdlib.dj
+++ b/docs/stdlib.dj
@@ -2264,6 +2264,36 @@ $ MYFLAG=42 jaq -n '$ENV.MYFLAG'
 
 The filter `env` is equivalent to `$ENV`.
 
+### `input_filename`, `$input_filename`
+
+The filter `input_filename` returns:
+
+- The name of the file whose input is currently being filtered;
+- `"<stdin>"` when filtering data on standard input;
+- Or `null` if the data source is unknown (such as when using `--null-input`).
+
+This filter is implemented on top of the `$input_filename` variable, which gets set by the CLI automatically.
+
+Note that the CLI will only set the variable if it has not been explicitly set on the command line; for example,
+`jaq 'input_filename' ./data.json` will output `"./data.json"`, but
+`jaq --argjson input_filename 123 'input_filename' ./data.json` will output `123` instead.
+
+::: Compatibility
+`jq`'s version of the `input_filename/0` filter returns `"<stdin>"` when filtering data on standard input. While this
+behaviour has been preserved for `jaq`'s `input_filename/0` filter, the filter alone thus cannot be used to
+differentiate between filtering on standard input and filtering a file called `<stdin>`.
+
+To work around this, the `jaq` CLI sets the `$input_filename` variable to the actual input source: the path (if known),
+the _empty string_ for filtering data on standard input, or `null` if the data source is unknown. If your script needs
+to be able to distinguish between filtering data on standard input and filtering a file called `<stdin>`, use the
+variable rather than the filter.
+:::
+
+::: Advanced
+This filter and variable are only defined in the CLI, so are unavailable if you are using the `jaq-*` crates directly
+from Rust code.
+:::
+
 ### `repl`
 
 The filter `repl` starts an interactive REPL (read-eval-print-loop).
@@ -2281,6 +2311,10 @@ and it allows calls to `repl` anywhere in a filter, not only last in the pipelin
 `jq` does not have this filter.
 :::
 
+::: Advanced
+This filter is only defined in the CLI, so is unavailable if you are using the `jaq-*` crates directly from Rust code.
+:::
+
 
 {#unsupported-stdlib}
 ## Unsupported
@@ -2293,7 +2327,6 @@ This section lists filters present in `jq`, but not in jaq.
 - [`have_decnum`](https://jqlang.org/manual/#have_decnum)
 - [`$JQ_BUILD_CONFIGURATION`](https://jqlang.org/manual/#$jq_build_configuration)
 - [`builtins`](https://jqlang.org/manual/#builtins)
-- [`input_filename`](https://jqlang.org/manual/#input_filename)
 - [`input_line_number`](https://jqlang.org/manual/#input_line_number)
 
 jaq supports none of jq's

--- a/docs/stdlib.dj
+++ b/docs/stdlib.dj
@@ -2297,10 +2297,6 @@ and it allows calls to `repl` anywhere in a filter, not only last in the pipelin
 `jq` does not have this filter.
 :::
 
-::: Advanced
-This filter is only defined in the CLI, so is unavailable if you are using the `jaq-*` crates directly from Rust code.
-:::
-
 
 {#unsupported-stdlib}
 ## Unsupported

--- a/docs/stdlib.dj
+++ b/docs/stdlib.dj
@@ -2269,16 +2269,32 @@ The filter `env` is equivalent to `$ENV`.
 The filter `input_filename` returns
 the name of the file currently read, or
 `"<stdin>"` if standard input is currently read.
-If `--null-input` is used, this filter returns `null` instead.
 
 ```
 $ jaq --slurp 'input_filename' "examples/benches.json"
 "examples/benches.json"
 $ echo 0 | jaq 'input_filename'
 "<stdin>"
-$ jaq -n 'input_filename'
-null
 ```
+
+::: Compatibility
+In jq, this filter returns the name of the file most recently read from.
+This can lead to subtle differences compared to jaq. For example:
+
+```
+$ echo 0 | jaq --null-input '(., inputs) | input_filename'
+"<stdin>"
+"<stdin>"
+```
+
+Here, jq yields `null "<stdin>"`. Why?
+When executing the filter `.`, jq did not read any input, so
+`input_filename` returns `null`.
+However, when executing `inputs`, jq starts reading from standard input, so
+`input_filename` returns `"<stdin>"`.
+
+In contrast, jaq considers a file as being read even when it has only been opened.
+:::
 
 ### `repl`
 

--- a/jaq/src/defs.jq
+++ b/jaq/src/defs.jq
@@ -1,0 +1,2 @@
+# Input filename
+def input_filename: $input_filename | if . == "" then "<stdin>" end;

--- a/jaq/src/defs.jq
+++ b/jaq/src/defs.jq
@@ -1,2 +1,0 @@
-# Input filename
-def input_filename: $input_filename | if . == "" then "<stdin>" end;

--- a/jaq/src/filter.rs
+++ b/jaq/src/filter.rs
@@ -19,7 +19,7 @@ pub fn parse_compile(
 
     let vars: Vec<_> = vars.iter().map(|v| format!("${v}")).collect();
     let arena = Arena::default();
-    let loader = Loader::new(jaq_all::defs()).with_std_read(paths);
+    let loader = Loader::new(jaq_all::defs().chain(defs())).with_std_read(paths);
     //let loader = Loader::new([]).with_std_read(paths);
     let path = path.into();
     let modules = loader
@@ -56,4 +56,10 @@ pub(crate) fn run(
         f(v).map_err(Into::into)
     })?;
     Ok(last)
+}
+
+fn defs() -> impl Iterator<Item = load::parse::Def<&'static str>> {
+    load::parse(include_str!("defs.jq"), |p| p.defs())
+        .unwrap()
+        .into_iter()
 }

--- a/jaq/src/filter.rs
+++ b/jaq/src/filter.rs
@@ -59,7 +59,9 @@ pub(crate) fn run(
 }
 
 fn defs() -> impl Iterator<Item = load::parse::Def<&'static str>> {
-    load::parse(include_str!("defs.jq"), |p| p.defs())
-        .unwrap()
-        .into_iter()
+    core::iter::once(load::parse::Def {
+        name: "input_filename",
+        args: Vec::new(),
+        body: load::parse::Term::Var("$!input_filename"),
+    })
 }

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -105,7 +105,17 @@ impl Cli {
 }
 
 fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
-    let (var_names, mut vars): (Vec<String>, Vec<Val>) = binds(cli)?.into_iter().unzip();
+    let mut var_val = binds(cli)?;
+    let input_filename_idx = if var_val.iter().any(|(name, _)| name == "input_filename") {
+        // don't automatically set `$input_filename` for use by `input_filename/0` - the user has
+        // overridden it, respect that instead
+        None
+    } else {
+        let idx = var_val.len();
+        var_val.push(("input_filename".to_string(), Val::Null));
+        Some(idx)
+    };
+    let (var_names, mut vars): (Vec<String>, Vec<Val>) = var_val.into_iter().unzip();
 
     let (var_vals, filter) = match &cli.filter {
         None => (Vec::new(), Filter::default()),
@@ -119,14 +129,19 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
         }
     };
     vars.extend(var_vals);
-    let vars = jaq_all::jaq_core::Vars::new(vars);
-    //println!("Filter: {:?}", filter);
 
     let runner = &cli.runner();
     let writer = &runner.writer;
 
     let unwrap_or_json = |fmt: Option<Format>| fmt.unwrap_or_default();
     let last = if cli.files.is_empty() {
+        if let Some(idx) = input_filename_idx {
+            if !cli.null_input {
+                vars[idx] = Val::TStr(Default::default());
+            }
+        }
+        let vars = jaq_all::jaq_core::Vars::new(vars);
+
         let format = unwrap_or_json(cli.from);
         let s = read::read_string(format, io::stdin().lock())?;
         let inputs = read::read(format, io::stdin().lock(), &s, cli.slurp);
@@ -140,6 +155,14 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
             let format = unwrap_or_json(cli.from.or_else(|| Format::determine(path)));
             let s = read::bytes_str(format, &bytes)?;
             let inputs = read::parse(format, &bytes, s, cli.slurp);
+
+            let mut vars = vars.clone();
+            if let Some(idx) = input_filename_idx {
+                if !cli.null_input {
+                    vars[idx] = Val::utf8_str(file.as_os_str().as_encoded_bytes().to_owned());
+                }
+            }
+            let vars = jaq_all::jaq_core::Vars::new(vars);
 
             if cli.in_place {
                 // create a temporary file where output is written to

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -11,6 +11,7 @@ use filter::run;
 use jaq_all::data::{Filter, Runner};
 use jaq_all::fmts::read;
 use jaq_all::fmts::write::{with_stdout, write, Writer};
+use jaq_all::jaq_core::Vars;
 use jaq_all::json::write::{Pp, Styles};
 use jaq_all::json::Val;
 use jaq_all::load::{Color, FileReports, FileReportsDisp, Paint};
@@ -106,15 +107,8 @@ impl Cli {
 
 fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
     let mut var_val = binds(cli)?;
-    let input_filename_idx = if var_val.iter().any(|(name, _)| name == "input_filename") {
-        // don't automatically set `$input_filename` for use by `input_filename/0` - the user has
-        // overridden it, respect that instead
-        None
-    } else {
-        let idx = var_val.len();
-        var_val.push(("input_filename".to_string(), Val::Null));
-        Some(idx)
-    };
+    let input_filename_idx = var_val.len();
+    var_val.push(("!input_filename".to_string(), Val::Null));
     let (var_names, mut vars): (Vec<String>, Vec<Val>) = var_val.into_iter().unzip();
 
     let (var_vals, filter) = match &cli.filter {
@@ -135,12 +129,10 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
 
     let unwrap_or_json = |fmt: Option<Format>| fmt.unwrap_or_default();
     let last = if cli.files.is_empty() {
-        if let Some(idx) = input_filename_idx {
-            if !cli.null_input {
-                vars[idx] = Val::TStr(Default::default());
-            }
+        if !cli.null_input {
+            vars[input_filename_idx] = Val::utf8_str("<stdin>");
         }
-        let vars = jaq_all::jaq_core::Vars::new(vars);
+        let vars = Vars::new(vars);
 
         let format = unwrap_or_json(cli.from);
         let s = read::read_string(format, io::stdin().lock())?;
@@ -149,20 +141,18 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
     } else {
         let mut last = None;
         for file in &cli.files {
+            if !cli.null_input {
+                vars[input_filename_idx] =
+                    Val::utf8_str(file.as_os_str().to_string_lossy().into_owned());
+            }
+            let vars = Vars::new(vars.clone());
+
             let path = Path::new(file);
             let bytes = read::load_file(path)
                 .map_err(|e| Error::Io(Some(path.display().to_string()), e))?;
             let format = unwrap_or_json(cli.from.or_else(|| Format::determine(path)));
             let s = read::bytes_str(format, &bytes)?;
             let inputs = read::parse(format, &bytes, s, cli.slurp);
-
-            let mut vars = vars.clone();
-            if let Some(idx) = input_filename_idx {
-                if !cli.null_input {
-                    vars[idx] = Val::utf8_str(file.as_os_str().as_encoded_bytes().to_owned());
-                }
-            }
-            let vars = jaq_all::jaq_core::Vars::new(vars);
 
             if cli.in_place {
                 // create a temporary file where output is written to

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -130,9 +130,7 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
 
     let unwrap_or_json = |fmt: Option<Format>| fmt.unwrap_or_default();
     let last = if cli.files.is_empty() {
-        if !cli.null_input {
-            vars[input_filename_idx] = Val::utf8_str("<stdin>");
-        }
+        vars[input_filename_idx] = Val::utf8_str("<stdin>");
         let vars = Vars::new(vars);
 
         let format = unwrap_or_json(cli.from);
@@ -142,10 +140,8 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
     } else {
         let mut last = None;
         for file in &cli.files {
-            if !cli.null_input {
-                vars[input_filename_idx] =
-                    Val::utf8_str(file.as_os_str().to_string_lossy().into_owned());
-            }
+            vars[input_filename_idx] =
+                Val::utf8_str(file.as_os_str().to_string_lossy().into_owned());
             let vars = Vars::new(vars.clone());
 
             let path = Path::new(file);

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -123,6 +123,7 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
         }
     };
     vars.extend(var_vals);
+    //println!("Filter: {:?}", filter);
 
     let runner = &cli.runner();
     let writer = &runner.writer;

--- a/jaq/tests/golden.rs
+++ b/jaq/tests/golden.rs
@@ -1,14 +1,6 @@
 use std::{env, io, process, str};
 
-fn golden_test(args: &[&str], input: &str, out_ex: &str) -> io::Result<()> {
-    let mut child = process::Command::new(env!("CARGO_BIN_EXE_jaq"))
-        .args(args)
-        .stdin(process::Stdio::piped())
-        .stdout(process::Stdio::piped())
-        .spawn()?;
-
-    use io::Write;
-    child.stdin.take().unwrap().write_all(input.as_bytes())?;
+fn test_expected(child: process::Child, out_ex: &str) -> io::Result<()> {
     let output = child.wait_with_output()?;
     assert!(output.status.success());
 
@@ -18,9 +10,35 @@ fn golden_test(args: &[&str], input: &str, out_ex: &str) -> io::Result<()> {
     if out_ex.trim() != out_act.trim() {
         println!("Expected output:\n{}\n---", out_ex);
         println!("Actual output:\n{}\n---", out_act);
-        process::exit(2);
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "incorrect test output",
+        ));
     }
     Ok(())
+}
+
+fn golden_test(args: &[&str], input: &str, out_ex: &str) -> io::Result<()> {
+    let mut child = process::Command::new(env!("CARGO_BIN_EXE_jaq"))
+        .args(args)
+        .stdin(process::Stdio::piped())
+        .stdout(process::Stdio::piped())
+        .spawn()?;
+
+    use io::Write;
+    child.stdin.take().unwrap().write_all(input.as_bytes())?;
+
+    test_expected(child, out_ex)
+}
+
+fn test_no_input(args: &[&str], out_ex: &str) -> io::Result<()> {
+    let child = process::Command::new(env!("CARGO_BIN_EXE_jaq"))
+        .args(args)
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::piped())
+        .spawn()?;
+
+    test_expected(child, out_ex)
 }
 
 macro_rules! test {
@@ -182,4 +200,48 @@ test!(
     &["-c", "-L", "tests", r#"include "a"; [a, data, d]"#],
     "0",
     r#"["bcddd",[1,2],3]"#
+);
+
+#[test]
+fn input_filename_file() -> io::Result<()> {
+    test_no_input(
+        &["--slurp", "true | input_filename", "./tests/data.json"],
+        r#""./tests/data.json""#,
+    )
+}
+
+#[test]
+fn input_filename_override() -> io::Result<()> {
+    test_no_input(
+        &[
+            "--slurp",
+            "--argjson",
+            "input_filename",
+            "0",
+            "true | input_filename",
+            "./tests/data.json",
+        ],
+        r#"0"#,
+    )
+}
+
+test!(
+    input_filename_stdin,
+    &["true | input_filename"],
+    "0",
+    r#""<stdin>""#
+);
+
+test!(
+    input_filename_stdin_variable,
+    &["true | $input_filename"],
+    "0",
+    r#""""#
+);
+
+test!(
+    input_filename_null_input,
+    &["-n", "true | input_filename"],
+    "",
+    r#"null"#
 );

--- a/jaq/tests/golden.rs
+++ b/jaq/tests/golden.rs
@@ -1,6 +1,15 @@
 use std::{env, io, process, str};
 
-fn test_expected(child: process::Child, out_ex: &str) -> io::Result<()> {
+fn golden_test(args: &[&str], input: &str, out_ex: &str) -> io::Result<()> {
+    let mut child = process::Command::new(env!("CARGO_BIN_EXE_jaq"))
+        .args(args)
+        .stdin(process::Stdio::piped())
+        .stdout(process::Stdio::piped())
+        .spawn()?;
+
+    use io::Write;
+    child.stdin.take().unwrap().write_all(input.as_bytes())?;
+
     let output = child.wait_with_output()?;
     assert!(output.status.success());
 
@@ -16,29 +25,6 @@ fn test_expected(child: process::Child, out_ex: &str) -> io::Result<()> {
         ));
     }
     Ok(())
-}
-
-fn golden_test(args: &[&str], input: &str, out_ex: &str) -> io::Result<()> {
-    let mut child = process::Command::new(env!("CARGO_BIN_EXE_jaq"))
-        .args(args)
-        .stdin(process::Stdio::piped())
-        .stdout(process::Stdio::piped())
-        .spawn()?;
-
-    use io::Write;
-    child.stdin.take().unwrap().write_all(input.as_bytes())?;
-
-    test_expected(child, out_ex)
-}
-
-fn test_no_input(args: &[&str], out_ex: &str) -> io::Result<()> {
-    let child = process::Command::new(env!("CARGO_BIN_EXE_jaq"))
-        .args(args)
-        .stdin(process::Stdio::null())
-        .stdout(process::Stdio::piped())
-        .spawn()?;
-
-    test_expected(child, out_ex)
 }
 
 macro_rules! test {
@@ -202,46 +188,23 @@ test!(
     r#"["bcddd",[1,2],3]"#
 );
 
-#[test]
-fn input_filename_file() -> io::Result<()> {
-    test_no_input(
-        &["--slurp", "true | input_filename", "./tests/data.json"],
-        r#""./tests/data.json""#,
-    )
-}
-
-#[test]
-fn input_filename_override() -> io::Result<()> {
-    test_no_input(
-        &[
-            "--slurp",
-            "--argjson",
-            "input_filename",
-            "0",
-            "true | input_filename",
-            "./tests/data.json",
-        ],
-        r#"0"#,
-    )
-}
+test!(
+    input_filename_file,
+    &["--slurp", "input_filename", "./tests/data.json"],
+    "",
+    r#""./tests/data.json""#
+);
 
 test!(
     input_filename_stdin,
-    &["true | input_filename"],
+    &["input_filename"],
     "0",
     r#""<stdin>""#
 );
 
 test!(
-    input_filename_stdin_variable,
-    &["true | $input_filename"],
-    "0",
-    r#""""#
-);
-
-test!(
     input_filename_null_input,
-    &["-n", "true | input_filename"],
+    &["-n", "input_filename"],
     "",
     r#"null"#
 );

--- a/jaq/tests/golden.rs
+++ b/jaq/tests/golden.rs
@@ -187,24 +187,3 @@ test!(
     "0",
     r#"["bcddd",[1,2],3]"#
 );
-
-test!(
-    input_filename_file,
-    &["--slurp", "input_filename", "./tests/data.json"],
-    "",
-    r#""./tests/data.json""#
-);
-
-test!(
-    input_filename_stdin,
-    &["input_filename"],
-    "0",
-    r#""<stdin>""#
-);
-
-test!(
-    input_filename_null_input,
-    &["-n", "input_filename"],
-    "",
-    r#"null"#
-);

--- a/jaq/tests/golden.rs
+++ b/jaq/tests/golden.rs
@@ -9,7 +9,6 @@ fn golden_test(args: &[&str], input: &str, out_ex: &str) -> io::Result<()> {
 
     use io::Write;
     child.stdin.take().unwrap().write_all(input.as_bytes())?;
-
     let output = child.wait_with_output()?;
     assert!(output.status.success());
 


### PR DESCRIPTION
Adds the `input_filename` filter from `jq` in the manner suggested [here](https://github.com/01mf02/jaq/issues/144#issuecomment-4343283722) (binding a variable and using normal filters to expose it).

Also adds a `input_filename/1` version that can override the value returned when filtering data on stdin; `jq` returns "<stdin>" in that case, which cannot be differentiated from filtering a _file_ called "<stdin>" - a rare occurrence, sure, but it costs almost nothing to add handling for that. The `/0` variant - which is the only variant that `jq` itself implements - is compatible with the `jq` version in all the circumstances I could think to test.

This implementation adds the variable fallback handling in an ad-hoc manner in `jaq-core`; it may make more sense to only define it in the main `jaq` crate (the CLI), but this approach provides the most flexibility both to CLI users and to people using the Rust crates directly.

Closes: #144 

### Checklist

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).