### PR TITLE
fix(jaq-json): don't panic when indexing an array by an empty array

### DIFF
--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -491,10 +491,17 @@ impl Val {
                 .and_then(|i| abs_index(i, a.len()))
                 .map(|i| a[i].clone()),
             (Val::Arr(x), Val::Arr(y)) => {
-                // adapted from the implementation of the `indices` filter
-                let iw = x.windows(y.len()).enumerate();
-                let indices = iw.filter_map(|(i, w)| (w == **y).then_some(i));
-                Some(indices.map(Val::from).collect())
+                // adapted from the implementation of the `indices` filter.
+                // An empty needle matches nothing (like jq and the `indices`
+                // builtin); guard it before `windows`, which panics on a
+                // zero window size.
+                if y.is_empty() {
+                    Some(core::iter::empty::<Val>().collect())
+                } else {
+                    let iw = x.windows(y.len()).enumerate();
+                    let indices = iw.filter_map(|(i, w)| (w == **y).then_some(i));
+                    Some(indices.map(Val::from).collect())
+                }
             }
             (Val::Obj(o), i) => o.get(i).cloned(),
             (v @ (Val::BStr(_) | Val::TStr(_) | Val::Arr(_)), Val::Obj(o)) => {

--- a/jaq-json/tests/funs.rs
+++ b/jaq-json/tests/funs.rs
@@ -57,6 +57,9 @@ yields!(indices_arr_str, r#"["a", "b", "c"] | indices("b")"#, [1]);
 yields!(indices_arr_empty, "[0, 1] | indices([])", json!([]));
 yields!(indices_arr_larger, "[1, 2] | indices([1, 2, 3])", json!([]));
 
+yields!(index_arr_empty, "[1, 2, 3] | .[[]]", json!([]));
+yields!(index_arr_match, "[0, 1, 2, 1, 2] | .[[1, 2]]", [1, 3]);
+
 yields!(indices_arr_overlap, "[0, 0, 0] | indices([0, 0])", [0, 1]);
 yields!(indices_str_overlap, r#""aaa" | indices("aa")"#, [0, 1]);
 yields!(indices_str_gb1, r#""🇬🇧!" | indices("!")"#, [2]);


### PR DESCRIPTION
Fixes #437

Indexing an array by an empty array (`.[[]]`, and the `getpath([[]])` / `nth(.)` paths that route through it) panicked in `slice::windows(0)` ("window size must be non-zero") and aborted, instead of returning `[]` like jq. Because it is a panic rather than a jaq error value, `?`/`try` could not catch it.

The array-by-array arm of `Val::index_opt` computed `x.windows(y.len())`; when the index array `y` is empty, `y.len() == 0` and `slice::windows(0)` panics. jaq's own `indices([])` builtin already guards this case.

This guards the empty needle before calling `windows`, returning an empty array — matching jq and `indices([])`. Adds regression tests (`index_arr_empty`, `index_arr_match`) in `jaq-json/tests/funs.rs`.
