### PR TITLE
Update to new `bstr` for upstream `.chars().count()` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,13 +43,13 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/jaq-json/src/funs.rs
+++ b/jaq-json/src/funs.rs
@@ -17,7 +17,7 @@ impl Val {
         match self {
             Val::Null => Ok(Val::from(0usize)),
             Val::Num(n) => Ok(Val::Num(n.length())),
-            Val::TStr(s) => Ok(Val::from(utf8_length(s))),
+            Val::TStr(s) => Ok(Val::from(s.chars().count())),
             Val::BStr(b) => Ok(Val::from(b.len())),
             Val::Arr(a) => Ok(Val::from(a.len())),
             Val::Obj(o) => Ok(Val::from(o.len())),
@@ -143,32 +143,6 @@ type ValRs<'a> = BoxIter<'a, ValR>;
 /// Apply a function to bytes and yield the resulting value results.
 pub fn bytes_valrs(b: Bytes, f: impl FnOnce(&[u8]) -> ValRs) -> ValRs<'static> {
     Box::new(BytesValRs::new(b, |b| f(b)))
-}
-
-/// Obtain length of string that is assumed to be UTF-8 encoded.
-///
-/// This can be removed once https://github.com/BurntSushi/bstr/pull/223 lands.
-fn utf8_length(mut s: &[u8]) -> usize {
-    let mut count = 0;
-    loop {
-        // ASCII fast path taken if two consecutive ASCII chars found
-        match s {
-            [fst, snd, ..] if *fst <= 0x7F && *snd <= 0x7F => {
-                let size = s.find_non_ascii_byte().unwrap_or(s.len());
-                count += size;
-                s = &s[size..];
-            }
-            _ => (),
-        }
-
-        let (_ch, size) = bstr::decode_utf8(s);
-        if size == 0 {
-            return count;
-        } else {
-            count += 1;
-            s = &s[size..];
-        }
-    }
 }
 
 /// Functions of the standard library.


### PR DESCRIPTION
This should not change the actual behaviour, the [new `.chars().count()`](https://github.com/BurntSushi/bstr/pull/223) is identical to jaq's previous implementation.

Thanks to @BurntSushi for [enabling this change](https://github.com/BurntSushi/bstr/pull/228) without changing jaq's MSRV.