### PR TITLE
Disable default features for workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ resolver = "2"
 
 [workspace.dependencies]
 jaq-core = { version = "3.1.0", path = "jaq-core", default-features = false }
-jaq-std  = { version = "3.0.1", path = "jaq-std", default-features = false  }
+jaq-std  = { version = "3.0.1", path = "jaq-std" , default-features = false }
 jaq-json = { version = "2.0.1", path = "jaq-json", default-features = false }
 jaq-fmts = { version = "0.1.0", path = "jaq-fmts", default-features = false }
-jaq-all  = { version = "0.2.0", path = "jaq-all", default-features = false  }
+jaq-all  = { version = "0.2.0", path = "jaq-all" , default-features = false }
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-jaq-core = { version = "3.1.0", path = "jaq-core" }
-jaq-std  = { version = "3.0.1", path = "jaq-std"  }
-jaq-json = { version = "2.0.1", path = "jaq-json" }
-jaq-fmts = { version = "0.1.0", path = "jaq-fmts" }
-jaq-all  = { version = "0.2.0", path = "jaq-all"  }
+jaq-core = { version = "3.1.0", path = "jaq-core", default-features = false }
+jaq-std  = { version = "3.0.1", path = "jaq-std", default-features = false  }
+jaq-json = { version = "2.0.1", path = "jaq-json", default-features = false }
+jaq-fmts = { version = "0.1.0", path = "jaq-fmts", default-features = false }
+jaq-all  = { version = "0.2.0", path = "jaq-all", default-features = false  }
 
 [profile.release]
 strip = true

--- a/jaq-all/Cargo.toml
+++ b/jaq-all/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["jq"]
 rust-version = "1.70"
 
 [features]
-default = ["formats", "all-std"]
+default = ["formats", "std-all"]
 formats = ["jaq-fmts/all"]
-all-std = ["jaq-std/std", "jaq-std/format", "jaq-std/log", "jaq-std/math", "jaq-std/regex", "jaq-std/time"]
+std-all = ["jaq-std/default"]
 
 [dependencies]
 jaq-core = { workspace = true }

--- a/jaq-all/Cargo.toml
+++ b/jaq-all/Cargo.toml
@@ -11,8 +11,9 @@ keywords = ["jq"]
 rust-version = "1.70"
 
 [features]
-default = ["formats"]
+default = ["formats", "all-std"]
 formats = ["jaq-fmts/all"]
+all-std = ["jaq-std/std", "jaq-std/format", "jaq-std/log", "jaq-std/math", "jaq-std/regex", "jaq-std/time"]
 
 [dependencies]
 jaq-core = { workspace = true }

--- a/jaq-all/src/data.rs
+++ b/jaq-all/src/data.rs
@@ -1,5 +1,4 @@
 //! Commonly used data for filter compilation & execution.
-use crate::{compile_with, FileReports, Fun};
 use jaq_core::{data, DataT, Lut, Vars};
 use jaq_fmts::write::Writer;
 use jaq_json::{Val, ValX};
@@ -61,7 +60,7 @@ impl Runner {
 
 /// Functions from [`jaq_std`] and [`jaq_json`].
 #[cfg(feature = "all-std")]
-pub fn base_funs() -> impl Iterator<Item = Fun<DataKind>> {
+pub fn base_funs() -> impl Iterator<Item = crate::Fun<DataKind>> {
     let run = jaq_core::native::run::<DataKind>;
     let core = jaq_core::funs::<DataKind>();
     let std = jaq_std::funs::<DataKind>();
@@ -71,14 +70,14 @@ pub fn base_funs() -> impl Iterator<Item = Fun<DataKind>> {
 
 /// Base functions ([`base_funs`]) plus functions from [`jaq_fmts`].
 #[cfg(all(feature = "formats", feature = "all-std"))]
-pub fn funs() -> impl Iterator<Item = Fun<DataKind>> {
+pub fn funs() -> impl Iterator<Item = crate::Fun<DataKind>> {
     base_funs().chain(jaq_fmts::funs())
 }
 
 /// Compile a filter without access to external files/variables, including all functions/definitions.
 #[cfg(all(feature = "formats", feature = "all-std"))]
-pub fn compile(code: &str) -> Result<Filter, Vec<FileReports>> {
-    compile_with(code, crate::defs(), funs(), &[])
+pub fn compile(code: &str) -> Result<Filter, Vec<crate::FileReports>> {
+    crate::compile_with(code, crate::defs(), funs(), &[])
 }
 
 /// Run a filter with given input values and run `f` for every value output.

--- a/jaq-all/src/data.rs
+++ b/jaq-all/src/data.rs
@@ -59,7 +59,7 @@ impl Runner {
 }
 
 /// Functions from [`jaq_std`] and [`jaq_json`].
-#[cfg(feature = "all-std")]
+#[cfg(feature = "std-all")]
 pub fn base_funs() -> impl Iterator<Item = crate::Fun<DataKind>> {
     let run = jaq_core::native::run::<DataKind>;
     let core = jaq_core::funs::<DataKind>();
@@ -69,13 +69,13 @@ pub fn base_funs() -> impl Iterator<Item = crate::Fun<DataKind>> {
 }
 
 /// Base functions ([`base_funs`]) plus functions from [`jaq_fmts`].
-#[cfg(all(feature = "formats", feature = "all-std"))]
+#[cfg(all(feature = "formats", feature = "std-all"))]
 pub fn funs() -> impl Iterator<Item = crate::Fun<DataKind>> {
     base_funs().chain(jaq_fmts::funs())
 }
 
 /// Compile a filter without access to external files/variables, including all functions/definitions.
-#[cfg(all(feature = "formats", feature = "all-std"))]
+#[cfg(all(feature = "formats", feature = "std-all"))]
 pub fn compile(code: &str) -> Result<Filter, Vec<crate::FileReports>> {
     crate::compile_with(code, crate::defs(), funs(), &[])
 }

--- a/jaq-all/src/data.rs
+++ b/jaq-all/src/data.rs
@@ -60,6 +60,7 @@ impl Runner {
 }
 
 /// Functions from [`jaq_std`] and [`jaq_json`].
+#[cfg(feature = "all-std")]
 pub fn base_funs() -> impl Iterator<Item = Fun<DataKind>> {
     let run = jaq_core::native::run::<DataKind>;
     let core = jaq_core::funs::<DataKind>();
@@ -69,13 +70,13 @@ pub fn base_funs() -> impl Iterator<Item = Fun<DataKind>> {
 }
 
 /// Base functions ([`base_funs`]) plus functions from [`jaq_fmts`].
-#[cfg(feature = "formats")]
+#[cfg(all(feature = "formats", feature = "all-std"))]
 pub fn funs() -> impl Iterator<Item = Fun<DataKind>> {
     base_funs().chain(jaq_fmts::funs())
 }
 
 /// Compile a filter without access to external files/variables, including all functions/definitions.
-#[cfg(feature = "formats")]
+#[cfg(all(feature = "formats", feature = "all-std"))]
 pub fn compile(code: &str) -> Result<Filter, Vec<FileReports>> {
     let defs = jaq_core::defs()
         .chain(jaq_std::defs())

--- a/jaq-all/src/data.rs
+++ b/jaq-all/src/data.rs
@@ -78,10 +78,7 @@ pub fn funs() -> impl Iterator<Item = Fun<DataKind>> {
 /// Compile a filter without access to external files/variables, including all functions/definitions.
 #[cfg(all(feature = "formats", feature = "all-std"))]
 pub fn compile(code: &str) -> Result<Filter, Vec<FileReports>> {
-    let defs = jaq_core::defs()
-        .chain(jaq_std::defs())
-        .chain(jaq_json::defs());
-    compile_with(code, defs, funs(), &[])
+    compile_with(code, crate::defs(), funs(), &[])
 }
 
 /// Run a filter with given input values and run `f` for every value output.

--- a/jaq-fmts/Cargo.toml
+++ b/jaq-fmts/Cargo.toml
@@ -23,7 +23,7 @@ tabular = ["aho-corasick"]
 [dependencies]
 jaq-core = { workspace = true }
 jaq-std  = { workspace = true }
-jaq-json = { workspace = true }
+jaq-json = { workspace = true, features = ["std"] }
 
 aho-corasick = { version = "1.0", optional = true }
 bstr = "1"

--- a/jaq-fmts/src/lib.rs
+++ b/jaq-fmts/src/lib.rs
@@ -10,6 +10,7 @@ extern crate std;
 pub mod read;
 pub mod write;
 
+#[cfg(feature = "all")]
 use jaq_core::native::{run, Fun};
 
 #[cfg(feature = "all")]

--- a/jaq-fmts/src/write/mod.rs
+++ b/jaq-fmts/src/write/mod.rs
@@ -1,6 +1,7 @@
 //! Write values in different formats.
 #[cfg(feature = "cbor")]
 pub mod cbor;
+#[cfg(feature = "tabular")]
 pub mod tabular;
 #[cfg(feature = "toml")]
 pub mod toml;

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70"
 [features]
 default = ["std"]
 sync = []
-std = ["hifijson/std"]
+std = ["hifijson/std", "jaq-core/std", "jaq-std/std"]
 serde = ["serde_core"]
 
 [dependencies]

--- a/jaq-play/Cargo.toml
+++ b/jaq-play/Cargo.toml
@@ -22,7 +22,7 @@ wasm-opt = ['-O','--all-features']
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-jaq-all  = { workspace = true }
+jaq-all  = { workspace = true, features = ["formats", "std-all"] }
 
 aho-corasick = "1.1.2"
 log = "0.4.17"

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.70"
 [features]
 default = ["std", "format", "log", "math", "regex", "time"]
 regex = ["regex-bites"]
-std = []
+std = ["jaq-core/std"]
 format = ["aho-corasick", "base64", "urlencoding"]
 math = ["libm"]
 time = ["jiff"]

--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70"
 default = ["mimalloc"]
 
 [dependencies]
-jaq-all  = { workspace = true }
+jaq-all  = { workspace = true, features = ["formats", "all-std"] }
 
 dirs = { version = "6.0" }
 env_logger = { version = "0.10.0", default-features = false }

--- a/jaq/Cargo.toml
+++ b/jaq/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70"
 default = ["mimalloc"]
 
 [dependencies]
-jaq-all  = { workspace = true, features = ["formats", "all-std"] }
+jaq-all  = { workspace = true, features = ["formats", "std-all"] }
 
 dirs = { version = "6.0" }
 env_logger = { version = "0.10.0", default-features = false }


### PR DESCRIPTION
This allows actually disabling features on the various libraries and that having an actual effect. Now, by default, dependent features are not enabled unless the user asks for them or the library absolutely requires it. For example, jaq-all by default requires pretty much all features on jaq-std but this can be disabled by disabling the (only) new feature all-std.

This also adds the correct config for the tabular feature in jaq-fmts, which wouldn’t compile with this feature disabled beforehand.

This appears to be a breaking change for jaq-all if you disable default features (not if you leave them enabled), since jaq-all is missing three functions without the new "all-std" feature. However it’s not breaking for jaq itself (which still enables everything), or jaq-json (which just has to do some more work under the `std` feature), or jaq-core (which is untouched). For jaq-fmts this is a bugfix, enabling compilation with the tabular feature disabled.

Fixes #446. Fixes #431, where you are required to disable the new `all-std` feature, which also disables a few functions.

I have verified the dependency tree under --no-default-features in the relevant places and confirmed that the dependencies are minimal and as I expect them.

### Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).