### PR TITLE
Flush output per value only when stdout is a terminal

### DIFF
--- a/docs/cli.dj
+++ b/docs/cli.dj
@@ -354,6 +354,21 @@ $ echo [1, [2]] | jaq       | jaq -Rs
 
 Use _N_ spaces for indentation (default: 2).
 
+{#--unbuffered}
+### `--unbuffered`
+
+Flush the output after each value.
+
+When the output is not a terminal, jaq buffers it and
+flushes it only once all values have been written.
+This flag makes jaq flush the output after each value instead,
+which is useful when another process consumes jaq's output as
+soon as it is produced; for example:
+
+```
+jaq --unbuffered .a live.json | while read -r a; do echo "got $a"; done
+```
+
 ### `NO_COLOR`
 
 If the environment variable `NO_COLOR` is set to a non-empty value, then

--- a/jaq-all/examples/main.rs
+++ b/jaq-all/examples/main.rs
@@ -1,6 +1,6 @@
 use jaq_all::{data, fmts, load};
 use jaq_core::unwrap_valr;
-use std::io::{self, Error, ErrorKind};
+use std::io::{self, Error, ErrorKind, Write};
 
 fn main() -> io::Result<()> {
     let filter = std::env::args()
@@ -21,5 +21,6 @@ fn main() -> io::Result<()> {
     data::run(&runner, &filter, vars, inputs, fi, |v| {
         let v = unwrap_valr(v).map_err(|e| Error::new(ErrorKind::Other, e.to_string()));
         fmts::write::write(stdout, &runner.writer, &v?)
-    })
+    })?;
+    stdout.flush()
 }

--- a/jaq-fmts/src/write/formats.rs
+++ b/jaq-fmts/src/write/formats.rs
@@ -47,7 +47,5 @@ pub fn write(w: &mut dyn Write, writer: &Writer, val: &Val) -> Result {
         writeln!(w, "...")?;
     }
 
-    // when running `jaq -jn '"prompt> " | (., input)'`,
-    // this flush is necessary to make "prompt> " appear first
-    w.flush()
+    Ok(())
 }

--- a/jaq-fmts/src/write/mod.rs
+++ b/jaq-fmts/src/write/mod.rs
@@ -33,12 +33,22 @@ pub struct Writer {
     pub join: bool,
 }
 
-/// Buffer writes if stdout is terminal, else just lock stdout.
-pub fn with_stdout<T>(f: impl FnOnce(&mut dyn Write) -> T) -> T {
+/// Run `f` on locked stdout, buffering writes if stdout is not a terminal.
+///
+/// The closure also receives whether stdout is a terminal, so that
+/// it can decide whether to flush after individual outputs.
+/// If stdout is not a terminal, then the buffer is flushed at the end,
+/// propagating any error that occurs during the flush.
+pub fn with_stdout<T, E: From<io::Error>>(
+    f: impl FnOnce(&mut dyn Write, bool) -> Result<T, E>,
+) -> Result<T, E> {
     let stdout = io::stdout();
     if stdout.is_terminal() {
-        f(&mut stdout.lock())
+        f(&mut stdout.lock(), true)
     } else {
-        f(&mut io::BufWriter::new(stdout.lock()))
+        let mut w = io::BufWriter::new(stdout.lock());
+        let y = f(&mut w, false)?;
+        w.flush()?;
+        Ok(y)
     }
 }

--- a/jaq-fmts/src/write/mod.rs
+++ b/jaq-fmts/src/write/mod.rs
@@ -39,6 +39,10 @@ pub struct Writer {
 /// it can decide whether to flush after individual outputs.
 /// If stdout is not a terminal, then the buffer is flushed at the end,
 /// propagating any error that occurs during the flush.
+///
+/// Note that nested calls of this function buffer independently;
+/// in particular, output written by an inner call may appear before
+/// output that an outer call has written, but not yet flushed.
 pub fn with_stdout<T, E: From<io::Error>>(
     f: impl FnOnce(&mut dyn Write, bool) -> Result<T, E>,
 ) -> Result<T, E> {
@@ -47,8 +51,11 @@ pub fn with_stdout<T, E: From<io::Error>>(
         f(&mut stdout.lock(), true)
     } else {
         let mut w = io::BufWriter::new(stdout.lock());
-        let y = f(&mut w, false)?;
-        w.flush()?;
+        let y = f(&mut w, false);
+        let flushed = w.flush();
+        // if both the closure and the flush fail, return the closure's error
+        let y = y?;
+        flushed?;
         Ok(y)
     }
 }

--- a/jaq/src/cli.rs
+++ b/jaq/src/cli.rs
@@ -27,6 +27,8 @@ pub struct Cli {
     pub monochrome_output: bool,
     pub tab: bool,
     pub indent: Option<usize>,
+    /// Flush output after each value, even when stdout is not a terminal.
+    pub unbuffered: bool,
 
     // Compilation options
     pub from_file: bool,
@@ -104,6 +106,7 @@ impl Cli {
             "color-output" => self.short('C', args)?,
             "monochrome-output" => self.short('M', args)?,
             "tab" => self.tab = true,
+            "unbuffered" => self.unbuffered = true,
             "indent" => {
                 self.indent = Some(args.next().and_then(int).ok_or(Error::Int("--indent"))?)
             }

--- a/jaq/src/funs.rs
+++ b/jaq/src/funs.rs
@@ -36,9 +36,11 @@ fn eval(runner: &Runner, code: String, input: Val) -> Result<(), Error> {
     let ctx = Vars::new(ctx);
     let inputs = core::iter::once(Ok(input));
     let writer = &runner.writer;
-    with_stdout(|out, tty| {
+    // always flush, because the REPL is interactive by nature:
+    // its outputs should be visible before the next prompt appears
+    with_stdout(|out, _tty| {
         run(runner, &filter, ctx, inputs, |v| {
-            write_flush(out, writer, &v, tty)
+            write_flush(out, writer, &v, true)
         })
     })?;
     Ok(())

--- a/jaq/src/funs.rs
+++ b/jaq/src/funs.rs
@@ -1,4 +1,4 @@
-use crate::{filter, run, with_stdout, write, Error, ErrorColor, Runner, Val};
+use crate::{filter, run, with_stdout, write_flush, Error, ErrorColor, Runner, Val};
 use jaq_all::data::DataKind;
 use jaq_all::jaq_core::native::{self, v, Filter, Fun};
 use jaq_all::jaq_core::{RunPtr, Vars};
@@ -36,7 +36,11 @@ fn eval(runner: &Runner, code: String, input: Val) -> Result<(), Error> {
     let ctx = Vars::new(ctx);
     let inputs = core::iter::once(Ok(input));
     let writer = &runner.writer;
-    with_stdout(|out| run(runner, &filter, ctx, inputs, |v| write(out, writer, &v)))?;
+    with_stdout(|out, tty| {
+        run(runner, &filter, ctx, inputs, |v| {
+            write_flush(out, writer, &v, tty)
+        })
+    })?;
     Ok(())
 }
 

--- a/jaq/src/help.txt
+++ b/jaq/src/help.txt
@@ -24,6 +24,7 @@ Output options:
   -M, --monochrome-output   Do not color output
       --tab                 Use tabs for indentation rather than spaces
       --indent <N>          Use N spaces for indentation [default: 2]
+      --unbuffered          Flush output after each value
       --to <FORMAT>         Write output in given format, e.g. cbor
 
 Compilation options:

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -23,6 +23,20 @@ use std::process::{ExitCode, Termination};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+/// Write a value, followed by a flush if `flush` is true.
+///
+/// When running `jaq -jn '"prompt> " | (., input)'` on a terminal,
+/// the flush is necessary to make "prompt> " appear before `input` blocks.
+/// When stdout is not a terminal, we do not flush after each value,
+/// because [`with_stdout`] flushes once at the end.
+fn write_flush(w: &mut dyn Write, writer: &Writer, v: &Val, flush: bool) -> io::Result<()> {
+    write(w, writer, v)?;
+    if flush {
+        w.flush()?;
+    }
+    Ok(())
+}
+
 extern crate alloc;
 
 fn main() -> io::Result<ExitCode> {
@@ -136,7 +150,11 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
         let format = unwrap_or_json(cli.from);
         let s = read::read_string(format, io::stdin().lock())?;
         let inputs = read::read(format, io::stdin().lock(), &s, cli.slurp);
-        with_stdout(|out| run(runner, &filter, vars, inputs, |v| write(out, writer, &v)))?
+        with_stdout(|out, tty| {
+            run(runner, &filter, vars, inputs, |v| {
+                write_flush(out, writer, &v, tty)
+            })
+        })?
     } else {
         let mut last = None;
         for file in &cli.files {
@@ -168,9 +186,9 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
                 tmp.persist(path).map_err(|e| Error::Io(None, e.into()))?;
                 std::fs::set_permissions(path, perms)?;
             } else {
-                last = with_stdout(|out| {
+                last = with_stdout(|out, tty| {
                     run(runner, &filter, vars.clone(), inputs, |v| {
-                        write(out, writer, &v)
+                        write_flush(out, writer, &v, tty)
                     })
                 })?;
             }

--- a/jaq/src/main.rs
+++ b/jaq/src/main.rs
@@ -152,7 +152,7 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
         let inputs = read::read(format, io::stdin().lock(), &s, cli.slurp);
         with_stdout(|out, tty| {
             run(runner, &filter, vars, inputs, |v| {
-                write_flush(out, writer, &v, tty)
+                write_flush(out, writer, &v, tty || cli.unbuffered)
             })
         })?
     } else {
@@ -188,7 +188,7 @@ fn real_main(cli: &Cli) -> Result<ExitCode, Error> {
             } else {
                 last = with_stdout(|out, tty| {
                     run(runner, &filter, vars.clone(), inputs, |v| {
-                        write_flush(out, writer, &v, tty)
+                        write_flush(out, writer, &v, tty || cli.unbuffered)
                     })
                 })?;
             }


### PR DESCRIPTION
Previously, `write()` flushed after every output value, which defeated the `BufWriter` that `with_stdout()` sets up for non-terminal output: each value cost one write syscall. On `jaq -n 'range(200000)' > /dev/null`, roughly 60% of the runtime was system time spent on these writes.

This PR moves the per-value flush out of `write()` and into the callers:

- `with_stdout()` now tells its closure whether stdout is a terminal, and flushes the buffer once at the end otherwise. It also propagates flush errors, which `BufWriter`'s silent flush-on-drop would previously have swallowed, and it flushes even when the closure fails, so that a filter error cannot mask a stdout failure.
- The CLI flushes per value only when stdout is a terminal, which preserves the behaviour that makes `"prompt> "` appear before `input` blocks in `jaq -jn '"prompt> " | (., input)'`.
- A new `--unbuffered` flag (matching jq) forces a flush after every output value even when stdout is not a terminal, for protocol-style usage such as a parent process reading jaq's output through a pipe. Documented in `docs/cli.dj`.
- The REPL always flushes per value, since it is interactive by nature.
- The `jaq-all` example flushes explicitly, since `write()` no longer does.

One known limitation, documented on `with_stdout()`: nested calls buffer independently, so output of a `repl` invoked with redirected stdout can appear before buffered output of the outer run. `--unbuffered` restores the previous ordering.

Benchmark (Apple Silicon, release build):

```
jaq -n 'range(200000)' > /dev/null    96.5 ms -> 16.6 ms  (5.8x)
```

Output is byte-identical to the previous behaviour in all cases; the change only affects when bytes reach the operating system.

Note that the changed `with_stdout()` signature is a source-breaking change for `jaq-fmts` users: the closure gains an `is_terminal` argument and must now return a `Result` whose error implements `From<io::Error>`.

Testing: full workspace test suite, the docs pipeline (`make all` in `docs/`, including the 89 embedded CLI tests), `cargo clippy -- -Dwarnings`, `cargo fmt --check`, and MSRV checks with Rust 1.69 (jaq-core) and 1.70 (workspace) all pass.
