### PR TITLE
Replace per-call Aho-Corasick automata by simple byte loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,7 +310,6 @@ dependencies = [
 name = "jaq-fmts"
 version = "0.1.0"
 dependencies = [
- "aho-corasick",
  "base64",
  "bstr",
  "bytes",
@@ -359,7 +349,6 @@ dependencies = [
 name = "jaq-play"
 version = "0.0.0"
 dependencies = [
- "aho-corasick",
  "console_log",
  "jaq-all",
  "js-sys",
@@ -372,7 +361,6 @@ dependencies = [
 name = "jaq-std"
 version = "3.0.1"
 dependencies = [
- "aho-corasick",
  "base64",
  "bstr",
  "jaq-core",

--- a/jaq-fmts/Cargo.toml
+++ b/jaq-fmts/Cargo.toml
@@ -18,14 +18,13 @@ cbor = ["ciborium-ll", "ciborium-io"]
 toml = ["toml-span"]
 xml = ["xmlparser"]
 yaml = ["saphyr-parser", "base64"]
-tabular = ["aho-corasick"]
+tabular = []
 
 [dependencies]
 jaq-core = { workspace = true }
 jaq-std  = { workspace = true }
 jaq-json = { workspace = true, features = ["std"] }
 
-aho-corasick = { version = "1.0", optional = true }
 bstr = "1"
 bytes = "1.10.1"
 memmap2 = "0.9"

--- a/jaq-fmts/src/write/tabular.rs
+++ b/jaq-fmts/src/write/tabular.rs
@@ -64,18 +64,40 @@ macro_rules! write_row {
     }};
 }
 
+/// Write `b`, replacing single bytes according to `escape`.
+fn write_escaped(
+    w: &mut dyn io::Write,
+    b: &[u8],
+    escape: impl Fn(u8) -> Option<&'static [u8]>,
+) -> io::Result<()> {
+    let mut rest = b;
+    while let Some((i, esc)) = rest
+        .iter()
+        .enumerate()
+        .find_map(|(i, b)| Some((i, escape(*b)?)))
+    {
+        w.write_all(&rest[..i])?;
+        w.write_all(esc)?;
+        rest = &rest[i + 1..];
+    }
+    w.write_all(rest)
+}
+
 fn write_csv_str(w: &mut dyn io::Write, b: &[u8]) -> io::Result<()> {
-    use bstr::ByteSlice;
     write!(w, "\"")?;
-    w.write_all(&b.replace(b"\"", b"\"\""))?;
+    write_escaped(w, b, |b| (b == b'"').then_some(b"\"\""))?;
     write!(w, "\"")
 }
 
 fn write_tsv_str(w: &mut dyn io::Write, b: &[u8]) -> io::Result<()> {
-    let pats = ["\n", "\r", "\t", "\\", "\0"];
-    let reps = ["\\n", "\\r", "\\t", "\\\\", "\\0"];
-    let ac = aho_corasick::AhoCorasick::new(pats).unwrap();
-    w.write_all(&ac.replace_all_bytes(b, &reps))
+    write_escaped(w, b, |b| match b {
+        b'\n' => Some(b"\\n"),
+        b'\r' => Some(b"\\r"),
+        b'\t' => Some(b"\\t"),
+        b'\\' => Some(b"\\\\"),
+        b'\0' => Some(b"\\0"),
+        _ => None,
+    })
 }
 
 impl Row {

--- a/jaq-fmts/tests/formats.rs
+++ b/jaq-fmts/tests/formats.rs
@@ -160,3 +160,22 @@ fn xml() {
     let xml2: Vec<_> = json_val.iter().map(serialise).collect();
     assert_eq!(xml, xml2.concat());
 }
+
+#[test]
+fn tabular() {
+    let json = br#"["a\tb\\c\nd\re\u0000f", "q\"q", 1, null]"#;
+    let val = read::json::parse_single(json).unwrap();
+    let row = write::tabular::Row::try_from(&val)
+        .map_err(|e| e.to_string())
+        .unwrap();
+
+    let mut tsv = Vec::new();
+    row.write_tsv(&mut tsv).unwrap();
+    // strings are escaped without quoting, null becomes empty
+    assert_eq!(tsv, b"a\\tb\\\\c\\nd\\re\\0f\tq\"q\t1\t");
+
+    let mut csv = Vec::new();
+    row.write_csv(&mut csv).unwrap();
+    // strings are quoted, with only `"` escaped (by doubling)
+    assert_eq!(csv, b"\"a\tb\\c\nd\re\0f\",\"q\"\"q\",1,");
+}

--- a/jaq-play/Cargo.toml
+++ b/jaq-play/Cargo.toml
@@ -24,7 +24,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 jaq-all  = { workspace = true, features = ["formats", "std-all"] }
 
-aho-corasick = "1.1.2"
 log = "0.4.17"
 
 console_log = { version = "1.0", features = ["color"] }

--- a/jaq-play/src/lib.rs
+++ b/jaq-play/src/lib.rs
@@ -61,16 +61,34 @@ fn html_styles() -> Styles {
     }
 }
 
-const AC_PATTERNS: &[&str] = &["&", "<", ">"];
-const AC_REPLACES: &[&str] = &["&amp;", "&lt;", "&gt;"];
+fn escape(c: u8) -> Option<&'static str> {
+    match c {
+        b'&' => Some("&amp;"),
+        b'<' => Some("&lt;"),
+        b'>' => Some("&gt;"),
+        _ => None,
+    }
+}
 
 fn escape_bytes(s: &[u8]) -> Vec<u8> {
-    let ac = aho_corasick::AhoCorasick::new(AC_PATTERNS).unwrap();
-    ac.replace_all_bytes(s, AC_REPLACES)
+    let mut out = Vec::with_capacity(s.len());
+    for b in s {
+        match escape(*b) {
+            Some(esc) => out.extend_from_slice(esc.as_bytes()),
+            None => out.push(*b),
+        }
+    }
+    out
 }
 fn escape_str(s: &str) -> String {
-    let ac = aho_corasick::AhoCorasick::new(AC_PATTERNS).unwrap();
-    ac.replace_all(s, AC_REPLACES)
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match u8::try_from(c).ok().and_then(escape) {
+            Some(esc) => out.push_str(esc),
+            None => out.push(c),
+        }
+    }
+    out
 }
 
 #[allow(dead_code)]

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70"
 default = ["std", "format", "log", "math", "regex", "time"]
 regex = ["regex-bites"]
 std = ["jaq-core/std"]
-format = ["aho-corasick", "base64", "urlencoding"]
+format = ["base64", "urlencoding"]
 math = ["libm"]
 time = ["jiff"]
 
@@ -26,7 +26,6 @@ jiff = { version = "0.2.15", optional = true }
 regex-bites = { version = "0.1", optional = true }
 log = { version = "0.4.17", optional = true }
 libm = { version = "0.2.7", optional = true }
-aho-corasick = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true }
 urlencoding = { version = "2.1.3", optional = true }
 

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -472,10 +472,48 @@ where
     ])
 }
 
+/// Entities corresponding to the characters `<`, `>`, `&`, `'`, and `"`.
 #[cfg(feature = "format")]
-fn replace(s: &[u8], patterns: &[&str], replacements: &[&str]) -> Vec<u8> {
-    let ac = aho_corasick::AhoCorasick::new(patterns).unwrap();
-    ac.replace_all_bytes(s, replacements)
+const HTML_ENTITIES: [(&[u8], u8); 5] = [
+    (b"&lt;", b'<'),
+    (b"&gt;", b'>'),
+    (b"&amp;", b'&'),
+    (b"&apos;", b'\''),
+    (b"&quot;", b'"'),
+];
+
+#[cfg(feature = "format")]
+fn escape_html(s: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len());
+    for b in s {
+        match HTML_ENTITIES.iter().find(|(_ent, c)| c == b) {
+            Some((ent, _c)) => out.extend_from_slice(ent),
+            None => out.push(*b),
+        }
+    }
+    out
+}
+
+#[cfg(feature = "format")]
+fn unescape_html(s: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(i) = rest.iter().position(|b| *b == b'&') {
+        out.extend_from_slice(&rest[..i]);
+        let tail = &rest[i..];
+        match HTML_ENTITIES.iter().find(|(ent, _c)| tail.starts_with(ent)) {
+            Some((ent, c)) => {
+                out.push(*c);
+                rest = &tail[ent.len()..];
+            }
+            None => {
+                out.push(b'&');
+                rest = &tail[1..];
+            }
+        }
+    }
+    out.extend_from_slice(rest);
+    out
 }
 
 #[cfg(feature = "format")]
@@ -483,14 +521,12 @@ fn format<D: DataT>() -> Box<[Filter<RunPtr<D>>]>
 where
     for<'a> D::V<'a>: ValT,
 {
-    const HTML_PATS: [&str; 5] = ["<", ">", "&", "\'", "\""];
-    const HTML_REPS: [&str; 5] = ["&lt;", "&gt;", "&amp;", "&apos;", "&quot;"];
     Box::new([
         ("escape_html", v(0), |cv| {
-            bome(cv.1.map_utf8_str(|s| replace(s, &HTML_PATS, &HTML_REPS)))
+            bome(cv.1.map_utf8_str(escape_html))
         }),
         ("unescape_html", v(0), |cv| {
-            bome(cv.1.map_utf8_str(|s| replace(s, &HTML_REPS, &HTML_PATS)))
+            bome(cv.1.map_utf8_str(unescape_html))
         }),
         ("encode_uri", v(0), |cv| {
             bome(cv.1.map_utf8_str(|s| urlencoding::encode_binary(s).to_string()))

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -96,6 +96,19 @@ yields!(
     r#""<p style='visibility: hidden'>sneaky</p>" | escape_html"#,
     "&lt;p style=&apos;visibility: hidden&apos;&gt;sneaky&lt;/p&gt;"
 );
+// entities are unescaped in a single pass without rescanning ("&amp;lt;"),
+// unknown or incomplete entities are preserved ("&x;", "&amp"), and
+// an entity directly after a lone ampersand is unescaped ("&&lt;")
+yields!(
+    unescape_html_entities,
+    r#""&amp;lt; &&lt; &x; &amp &lt;&gt;&quot;&apos;&amp;" | unescape_html"#,
+    "&lt; &< &x; &amp <>\"'&"
+);
+yields!(
+    escape_unescape_html,
+    r#""<a href=\"x&y\">'☃'</a>" | escape_html | unescape_html"#,
+    "<a href=\"x&y\">'☃'</a>"
+);
 yields!(
     encode_uri,
     r#""abc123 ?#+&[]" | encode_uri"#,


### PR DESCRIPTION
`escape_html`/`unescape_html` (jaq-std), `@csv`/`@tsv` field escaping (jaq-fmts), and the playground's HTML escaping (jaq-play) constructed a fresh Aho-Corasick automaton for every processed value. For short strings, the automaton build cost dwarfs the actual scan.

All of these replacements concern single bytes (or, for `unescape_html`, five fixed entities, none of which is a prefix of another), so a plain byte loop is equivalent to the previous `MatchKind::Standard` `replace_all` behaviour. For CSV/TSV, the loop also writes directly to the output instead of allocating an escaped copy of each field.

This removes the `aho-corasick` dependency from jaq-std, jaq-fmts, and jaq-play.

Benchmarks (Apple Silicon, release build):

```
map(@html) over 200k strings     2.36 s -> 81 ms  (29x)
.[] | @tsv over 50k rows         2.24 s -> 56 ms  (40x)
```

The second commit adds regression tests that pin down the preserved semantics: single-pass entity unescaping without rescanning (`"&amp;lt;"` yields `"&lt;"`), preservation of unknown or incomplete entities (`"&x;"`, `"&amp"`), and the escaping of control characters, backslashes, and quotes in TSV/CSV fields.

Verified byte-identical output against the previous build on an edge-case corpus (adjacent entities, lone ampersands, Unicode, embedded tabs/newlines/NUL), plus round-trip `escape_html | unescape_html` identity.

Testing: full workspace test suite, `cargo clippy -- -Dwarnings`, `cargo fmt --check`, MSRV checks with Rust 1.69 (jaq-core) and 1.70 (workspace), and `cargo check -p jaq-play --target wasm32-unknown-unknown` all pass.
