### PR TITLE
Cache the parsed value of decimal numbers

### DIFF
--- a/jaq-fmts/src/read/yaml.rs
+++ b/jaq-fmts/src/read/yaml.rs
@@ -218,7 +218,7 @@ fn parse_float(s: &str) -> Option<Val> {
         let f = f64::INFINITY;
         Some(Val::from(if sign == Some('-') { -f } else { f }))
     } else {
-        normalise_float(sign, rest).map(|f| Val::Num(Num::Dec(f.into())))
+        normalise_float(sign, rest).map(|f| Val::Num(Num::dec(f)))
     }
 }
 

--- a/jaq-fmts/src/write/cbor.rs
+++ b/jaq-fmts/src/write/cbor.rs
@@ -50,7 +50,7 @@ fn encode<W: Write>(v: &Val, encoder: &mut Encoder<W>) -> Result<(), W::Error> {
             encoder.bytes(&u.1, None)
         }
         Val::Num(Num::Float(f)) => encoder.push(Header::Float(*f)),
-        Val::Num(Num::Dec(d)) => encode(&Val::Num(Num::from_dec_str(d)), encoder),
+        Val::Num(Num::Dec(d)) => encode(&Val::Num(Num::Float(d.as_f64())), encoder),
         Val::TStr(s) => encoder.text(&String::from_utf8_lossy(s), None),
         Val::BStr(b) => encoder.bytes(b, None),
         Val::Arr(a) => {

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -29,7 +29,7 @@ use num_bigint::BigInt;
 use num_traits::{cast::ToPrimitive, Signed};
 
 pub use funs::{bytes_valrs, funs};
-pub use num::Num;
+pub use num::{Dec, Num};
 
 #[cfg(not(feature = "sync"))]
 pub use alloc::rc::Rc;

--- a/jaq-json/src/num.rs
+++ b/jaq-json/src/num.rs
@@ -27,7 +27,42 @@ pub enum Num {
     /// Floating-point number
     Float(f64),
     /// Decimal number
-    Dec(Rc<String>),
+    Dec(Rc<Dec>),
+}
+
+/// Decimal number, keeping its literal representation for precise output.
+///
+/// This caches the floating-point value of the literal, so that
+/// operations such as comparisons do not have to re-parse the literal.
+#[derive(Clone, Debug)]
+pub struct Dec {
+    lit: String,
+    num: f64,
+}
+
+impl Dec {
+    /// Create a decimal number from its literal representation.
+    pub fn new(lit: String) -> Self {
+        // TODO: changed to NaN!
+        let num = lit.parse().unwrap_or(f64::NAN);
+        Self { lit, num }
+    }
+
+    /// Literal representation of the number.
+    pub fn as_str(&self) -> &str {
+        &self.lit
+    }
+
+    /// Floating-point value of the number (NaN if the literal is invalid).
+    pub fn as_f64(&self) -> f64 {
+        self.num
+    }
+}
+
+impl fmt::Display for Dec {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.lit)
+    }
 }
 
 impl Num {
@@ -36,8 +71,13 @@ impl Num {
         Self::BigInt(i.into())
     }
 
+    /// Create a decimal number from its literal representation.
+    pub fn dec(lit: String) -> Self {
+        Self::Dec(Rc::new(Dec::new(lit)))
+    }
+
     pub(crate) fn from_str(s: &str) -> Self {
-        Self::from_str_radix(s, 10).unwrap_or_else(|| Self::Dec(Rc::new(s.to_string())))
+        Self::from_str_radix(s, 10).unwrap_or_else(|| Self::dec(s.to_string()))
     }
 
     /// Convert from an integral type to a machine-sized or big integer.
@@ -89,7 +129,7 @@ impl Num {
             Self::Int(n) => *n as f64,
             Self::BigInt(n) => n.to_f64().unwrap(),
             Self::Float(n) => *n,
-            Self::Dec(n) => n.parse().unwrap(),
+            Self::Dec(n) => n.num,
         }
     }
 
@@ -100,7 +140,7 @@ impl Num {
                 Sign::Plus | Sign::NoSign => Self::BigInt(i.clone()),
                 Sign::Minus => Self::BigInt(BigInt::from(i.magnitude().clone()).into()),
             },
-            Self::Dec(n) => Self::from_dec_str(n).length(),
+            Self::Dec(n) => Self::Float(n.num).length(),
             Self::Float(f) => Self::Float(f.abs()),
         }
     }
@@ -175,8 +215,8 @@ impl core::ops::Add for Num {
             (BigInt(x), BigInt(y)) => Self::big_int(&*x + &*y),
             (BigInt(i), Float(f)) | (Float(f), BigInt(i)) => Float(f + i.to_f64().unwrap()),
             (Float(x), Float(y)) => Float(x + y),
-            (Dec(n), r) => Self::from_dec_str(&n) + r,
-            (l, Dec(n)) => l + Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) + r,
+            (l, Dec(n)) => l + Float(n.num),
         }
     }
 }
@@ -196,8 +236,8 @@ impl core::ops::Sub for Num {
             (Float(f), BigInt(i)) => Float(f - i.to_f64().unwrap()),
             (BigInt(i), Float(f)) => Float(i.to_f64().unwrap() - f),
             (Float(x), Float(y)) => Float(x - y),
-            (Dec(n), r) => Self::from_dec_str(&n) - r,
-            (l, Dec(n)) => l - Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) - r,
+            (l, Dec(n)) => l - Float(n.num),
         }
     }
 }
@@ -215,8 +255,8 @@ impl core::ops::Mul for Num {
             (BigInt(i), Float(f)) | (Float(f), BigInt(i)) => Float(f * i.to_f64().unwrap()),
             (Float(f), Int(i)) | (Int(i), Float(f)) => Float(f * i as f64),
             (Float(x), Float(y)) => Float(x * y),
-            (Dec(n), r) => Self::from_dec_str(&n) * r,
-            (l, Dec(n)) => l * Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) * r,
+            (l, Dec(n)) => l * Float(n.num),
         }
     }
 }
@@ -231,8 +271,8 @@ impl core::ops::Div for Num {
             (BigInt(l), r) => Float(l.to_f64().unwrap()) / r,
             (l, BigInt(r)) => l / Float(r.to_f64().unwrap()),
             (Float(x), Float(y)) => Float(x / y),
-            (Dec(n), r) => Self::from_dec_str(&n) / r,
-            (l, Dec(n)) => l / Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) / r,
+            (l, Dec(n)) => l / Float(n.num),
         }
     }
 }
@@ -256,8 +296,8 @@ impl core::ops::Rem for Num {
             (BigInt(i), Float(f)) => Float(i.to_f64().unwrap() % f),
             (Float(f), BigInt(i)) => Float(f % i.to_f64().unwrap()),
             (Float(x), Float(y)) => Float(x % y),
-            (Dec(n), r) => Self::from_dec_str(&n) % r,
-            (l, Dec(n)) => l % Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) % r,
+            (l, Dec(n)) => l % Float(n.num),
         }
     }
 }
@@ -269,9 +309,9 @@ impl core::ops::Neg for Num {
             Self::Int(x) => int_or_big(x.checked_neg(), [x], |[x]| -x),
             Self::BigInt(x) => Self::big_int(-&*x),
             Self::Float(x) => Self::Float(-x),
-            Self::Dec(n) => match n.strip_prefix('-') {
-                Some(pos) => Self::Dec(pos.to_string().into()),
-                None => Self::Dec(alloc::format!("-{n}").into()),
+            Self::Dec(n) => match n.lit.strip_prefix('-') {
+                Some(pos) => Self::dec(pos.to_string()),
+                None => Self::dec(alloc::format!("-{n}")),
             },
         }
     }
@@ -292,7 +332,7 @@ impl Hash for Num {
                     f.to_ne_bytes().hash(state);
                 }
             }
-            Self::Dec(d) => Self::from_dec_str(d).hash(state),
+            Self::Dec(d) => Self::Float(d.num).hash(state),
             Self::BigInt(i) => {
                 let f = i.to_f64().unwrap();
                 if f.is_finite() {
@@ -338,8 +378,8 @@ impl PartialEq for Num {
             }
             (Self::Float(x), Self::Float(y)) => float_eq(*x, *y),
             (Self::Dec(x), Self::Dec(y)) if Rc::ptr_eq(x, y) => true,
-            (Self::Dec(n), y) => &Self::from_dec_str(n) == y,
-            (x, Self::Dec(n)) => x == &Self::from_dec_str(n),
+            (Self::Dec(n), y) => &Self::Float(n.num) == y,
+            (x, Self::Dec(n)) => x == &Self::Float(n.num),
         }
     }
 }
@@ -366,8 +406,8 @@ impl Ord for Num {
             (Self::Float(x), Self::BigInt(y)) => float_cmp(*x, y.to_f64().unwrap()),
             (Self::Float(x), Self::Float(y)) => float_cmp(*x, *y),
             (Self::Dec(x), Self::Dec(y)) if Rc::ptr_eq(x, y) => Ordering::Equal,
-            (Self::Dec(n), y) => Self::from_dec_str(n).cmp(y),
-            (x, Self::Dec(n)) => x.cmp(&Self::from_dec_str(n)),
+            (Self::Dec(n), y) => Self::Float(n.num).cmp(y),
+            (x, Self::Dec(n)) => x.cmp(&Self::Float(n.num)),
         }
     }
 }

--- a/jaq-json/src/read.rs
+++ b/jaq-json/src/read.rs
@@ -104,7 +104,7 @@ fn parse_num<L: LexAlloc>(lexer: &mut L) -> Result<Num, hifijson::Error> {
             if parts.is_int() {
                 Num::from_str_radix(num, 10).unwrap()
             } else {
-                Num::Dec(num.to_string().into())
+                Num::dec(num.to_string())
             }
         }
         _ => Err(hifijson::num::Error::ExpectedDigit)?,


### PR DESCRIPTION
Non-integer numbers read from JSON/YAML input are stored as decimal literals to preserve their exact representation on output. Previously, every comparison, hash, or arithmetic operation on such a number re-parsed its literal via `from_dec_str`, so sorting or deduplicating float-heavy data paid one string parse per comparison operand.

`Num::Dec` now stores a `Dec` struct that couples the literal with its parsed `f64` (NaN for invalid literals, as before), so all operations read the cached value. Round-trip printing is unchanged: output still uses only the literal.

Two side effects that seem like improvements:

- The `Dec` fields are private, which guarantees the previously implicit invariant that the cached value matches the literal. (Previously, `Num`'s `Rc<String>` payload could be constructed with arbitrary contents by downstream code.)
- `Num::as_f64` no longer panics on literals that fail to parse; it returns NaN, consistent with `from_dec_str`.

This is a source-breaking change for code that matches on or constructs `Num::Dec` directly; `Num::dec(String)` is the new constructor, and `Dec` (re-exported from the crate root) provides `as_str`/`as_f64` accessors.

Benchmark (Apple Silicon, release build):

```
sort of 200k floats    155 ms -> 59 ms  (2.6x)
```

Verified byte-identical output against the previous build for decimal round-trips (`100.00`, `1.5e3`, `-0.0`, big-integer literals), `sort`, `unique`, and `group_by` over the float corpus.

Testing: full workspace test suite, `cargo clippy -- -Dwarnings`, `cargo fmt --check`, and MSRV checks with Rust 1.69 (jaq-core) and 1.70 (workspace) all pass.
