### PR TITLE
Parse decimal program literals at compile time

### DIFF
--- a/jaq-core/src/compile.rs
+++ b/jaq-core/src/compile.rs
@@ -92,7 +92,10 @@ pub(crate) enum Term<T = TermId> {
     ToString,
 
     Int(isize),
-    Num(String),
+    /// Number literal that is not representable by [`Term::Int`],
+    /// optionally with its pre-parsed floating-point value
+    /// (present iff the literal is decimal, i.e. not an integer)
+    Num(String, Option<f64>),
     Str(String),
     /// Array construction (`[f]`)
     Arr(T),
@@ -665,7 +668,19 @@ impl<'s, F> Compiler<&'s str, F> {
 
                 return (t, tr_);
             }
-            Num(n) => n.parse().map_or_else(|_| Term::Num(n.into()), Term::Int),
+            Num(n) => match n.parse() {
+                Ok(i) => Term::Int(i),
+                // an integer literal that overflows `isize`
+                Err(_) if !n.contains(|c| matches!(c, '.' | 'e' | 'E')) => {
+                    Term::Num(n.into(), None)
+                }
+                // a decimal literal, whose value we parse once here,
+                // so that it does not have to be parsed at every evaluation
+                Err(_) => {
+                    let f = n.parse().unwrap_or(f64::NAN);
+                    Term::Num(n.into(), Some(f))
+                }
+            },
             TryCatch(try_, catch) => {
                 let catch = catch.map_or_else(|| Call("!empty", Vec::new()), |t| *t);
                 Term::TryCatch(self.iterm(*try_), self.iterm(catch))

--- a/jaq-core/src/filter.rs
+++ b/jaq-core/src/filter.rs
@@ -468,7 +468,13 @@ impl Id {
             Ast::Recurse => recurse_run(cv.1, &|v| v.values()),
             Ast::ToString => box_once(Ok(cv.1.into_string())),
             Ast::Int(n) => box_once(Ok(D::V::from(*n))),
-            Ast::Num(x) => box_once(D::V::from_num(x).map_err(Exn::from)),
+            Ast::Num(x, f) => box_once(
+                match f {
+                    Some(f) => D::V::from_dec(x, *f),
+                    None => D::V::from_num(x),
+                }
+                .map_err(Exn::from),
+            ),
             Ast::Str(s) => box_once(Ok(D::V::from(s.clone()))),
             Ast::Arr(f) => box_once(f.run(cv).collect()),
             Ast::ObjEmpty => box_once(D::V::from_map([]).map_err(Exn::from)),
@@ -581,7 +587,7 @@ impl Id {
         let proj_val = |(val, _path): &(D::V<'a>, _)| val.clone();
         match &cv.0.lut().terms[self.0] {
             Ast::ToString => err(cv.1 .0),
-            Ast::Int(_) | Ast::Num(_) | Ast::Str(_) => err(cv.1 .0),
+            Ast::Int(_) | Ast::Num(..) | Ast::Str(_) => err(cv.1 .0),
             Ast::Arr(_) | Ast::ObjEmpty | Ast::ObjSingle(..) => err(cv.1 .0),
             Ast::Neg(_) | Ast::Logic(..) | Ast::Math(..) | Ast::Cmp(..) => err(cv.1 .0),
             Ast::Update(..) | Ast::Assign(..) => err(cv.1 .0),
@@ -665,7 +671,7 @@ impl Id {
         let err = |v| box_once(Err(Exn::from(Error::path_expr(v))));
         match &cv.0.lut().terms[self.0] {
             Ast::ToString => err(cv.1),
-            Ast::Int(_) | Ast::Num(_) | Ast::Str(_) => err(cv.1),
+            Ast::Int(_) | Ast::Num(..) | Ast::Str(_) => err(cv.1),
             Ast::Arr(_) | Ast::ObjEmpty | Ast::ObjSingle(..) => err(cv.1),
             Ast::Neg(_) | Ast::Logic(..) | Ast::Math(..) | Ast::Cmp(..) => err(cv.1),
             Ast::Update(..) | Ast::Assign(..) => err(cv.1),

--- a/jaq-core/src/val.rs
+++ b/jaq-core/src/val.rs
@@ -74,6 +74,17 @@ pub trait ValT:
     /// The number should adhere to the format accepted by [`f64::from_str`].
     fn from_num(n: &str) -> ValR<Self>;
 
+    /// Create a number from a decimal literal and its floating-point value.
+    ///
+    /// Here, `num` is the output of `lit.parse::<f64>()`,
+    /// or NaN if parsing fails.
+    /// Implementations that store decimal literals can use `num` to
+    /// avoid parsing `lit` at every call.
+    fn from_dec(lit: &str, num: f64) -> ValR<Self> {
+        let _ = num;
+        Self::from_num(lit)
+    }
+
     /// Create an associative map (or object) from a sequence of key-value pairs.
     ///
     /// This is used when creating values with the syntax `{k: v}`.

--- a/jaq-fmts/src/read/yaml.rs
+++ b/jaq-fmts/src/read/yaml.rs
@@ -218,7 +218,7 @@ fn parse_float(s: &str) -> Option<Val> {
         let f = f64::INFINITY;
         Some(Val::from(if sign == Some('-') { -f } else { f }))
     } else {
-        normalise_float(sign, rest).map(|f| Val::Num(Num::Dec(f.into())))
+        normalise_float(sign, rest).map(|f| Val::Num(Num::dec(f)))
     }
 }
 

--- a/jaq-fmts/src/write/cbor.rs
+++ b/jaq-fmts/src/write/cbor.rs
@@ -50,7 +50,7 @@ fn encode<W: Write>(v: &Val, encoder: &mut Encoder<W>) -> Result<(), W::Error> {
             encoder.bytes(&u.1, None)
         }
         Val::Num(Num::Float(f)) => encoder.push(Header::Float(*f)),
-        Val::Num(Num::Dec(d)) => encode(&Val::Num(Num::from_dec_str(d)), encoder),
+        Val::Num(Num::Dec(d)) => encode(&Val::Num(Num::Float(d.as_f64())), encoder),
         Val::TStr(s) => encoder.text(&String::from_utf8_lossy(s), None),
         Val::BStr(b) => encoder.bytes(b, None),
         Val::Arr(a) => {

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -135,6 +135,11 @@ impl jaq_core::ValT for Val {
         Ok(Self::Num(Num::from_str(n)))
     }
 
+    fn from_dec(lit: &str, num: f64) -> ValR {
+        let dec = num::Dec::with_value(lit.to_owned(), num);
+        Ok(Self::Num(Num::Dec(Rc::new(dec))))
+    }
+
     fn from_map<I: IntoIterator<Item = (Self, Self)>>(iter: I) -> ValR {
         Ok(Self::obj(iter.into_iter().collect()))
     }

--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -29,7 +29,7 @@ use num_bigint::BigInt;
 use num_traits::{cast::ToPrimitive, Signed};
 
 pub use funs::{bytes_valrs, funs};
-pub use num::Num;
+pub use num::{Dec, Num};
 
 #[cfg(not(feature = "sync"))]
 pub use alloc::rc::Rc;

--- a/jaq-json/src/num.rs
+++ b/jaq-json/src/num.rs
@@ -48,6 +48,17 @@ impl Dec {
         Self { lit, num }
     }
 
+    /// Create a decimal number from its literal representation and its value.
+    ///
+    /// Here, `num` must be the output of `lit.parse::<f64>()`,
+    /// or NaN if parsing fails.
+    /// This is useful when the value of `lit` is already known,
+    /// because it avoids parsing `lit` again.
+    pub(crate) fn with_value(lit: String, num: f64) -> Self {
+        debug_assert!(num.to_bits() == lit.parse().unwrap_or(f64::NAN).to_bits());
+        Self { lit, num }
+    }
+
     /// Literal representation of the number.
     pub fn as_str(&self) -> &str {
         &self.lit

--- a/jaq-json/src/num.rs
+++ b/jaq-json/src/num.rs
@@ -27,7 +27,42 @@ pub enum Num {
     /// Floating-point number
     Float(f64),
     /// Decimal number
-    Dec(Rc<String>),
+    Dec(Rc<Dec>),
+}
+
+/// Decimal number, keeping its literal representation for precise output.
+///
+/// This caches the floating-point value of the literal, so that
+/// operations such as comparisons do not have to re-parse the literal.
+#[derive(Clone, Debug)]
+pub struct Dec {
+    lit: String,
+    num: f64,
+}
+
+impl Dec {
+    /// Create a decimal number from its literal representation.
+    pub fn new(lit: String) -> Self {
+        // TODO: changed to NaN!
+        let num = lit.parse().unwrap_or(f64::NAN);
+        Self { lit, num }
+    }
+
+    /// Literal representation of the number.
+    pub fn as_str(&self) -> &str {
+        &self.lit
+    }
+
+    /// Floating-point value of the number (NaN if the literal is invalid).
+    pub fn as_f64(&self) -> f64 {
+        self.num
+    }
+}
+
+impl fmt::Display for Dec {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.lit)
+    }
 }
 
 impl Num {
@@ -36,8 +71,13 @@ impl Num {
         Self::BigInt(i.into())
     }
 
+    /// Create a decimal number from its literal representation.
+    pub fn dec(lit: String) -> Self {
+        Self::Dec(Rc::new(Dec::new(lit)))
+    }
+
     pub(crate) fn from_str(s: &str) -> Self {
-        Self::from_str_radix(s, 10).unwrap_or_else(|| Self::Dec(Rc::new(s.to_string())))
+        Self::from_str_radix(s, 10).unwrap_or_else(|| Self::dec(s.to_string()))
     }
 
     /// Convert from an integral type to a machine-sized or big integer.
@@ -89,7 +129,7 @@ impl Num {
             Self::Int(n) => *n as f64,
             Self::BigInt(n) => n.to_f64().unwrap(),
             Self::Float(n) => *n,
-            Self::Dec(n) => n.parse().unwrap(),
+            Self::Dec(n) => n.num,
         }
     }
 
@@ -100,7 +140,7 @@ impl Num {
                 Sign::Plus | Sign::NoSign => Self::BigInt(i.clone()),
                 Sign::Minus => Self::BigInt(BigInt::from(i.magnitude().clone()).into()),
             },
-            Self::Dec(n) => Self::from_dec_str(n).length(),
+            Self::Dec(n) => Self::Float(n.num).length(),
             Self::Float(f) => Self::Float(f.abs()),
         }
     }
@@ -175,8 +215,8 @@ impl core::ops::Add for Num {
             (BigInt(x), BigInt(y)) => Self::big_int(&*x + &*y),
             (BigInt(i), Float(f)) | (Float(f), BigInt(i)) => Float(f + i.to_f64().unwrap()),
             (Float(x), Float(y)) => Float(x + y),
-            (Dec(n), r) => Self::from_dec_str(&n) + r,
-            (l, Dec(n)) => l + Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) + r,
+            (l, Dec(n)) => l + Float(n.num),
         }
     }
 }
@@ -196,8 +236,8 @@ impl core::ops::Sub for Num {
             (Float(f), BigInt(i)) => Float(f - i.to_f64().unwrap()),
             (BigInt(i), Float(f)) => Float(i.to_f64().unwrap() - f),
             (Float(x), Float(y)) => Float(x - y),
-            (Dec(n), r) => Self::from_dec_str(&n) - r,
-            (l, Dec(n)) => l - Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) - r,
+            (l, Dec(n)) => l - Float(n.num),
         }
     }
 }
@@ -215,8 +255,8 @@ impl core::ops::Mul for Num {
             (BigInt(i), Float(f)) | (Float(f), BigInt(i)) => Float(f * i.to_f64().unwrap()),
             (Float(f), Int(i)) | (Int(i), Float(f)) => Float(f * i as f64),
             (Float(x), Float(y)) => Float(x * y),
-            (Dec(n), r) => Self::from_dec_str(&n) * r,
-            (l, Dec(n)) => l * Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) * r,
+            (l, Dec(n)) => l * Float(n.num),
         }
     }
 }
@@ -231,8 +271,8 @@ impl core::ops::Div for Num {
             (BigInt(l), r) => Float(l.to_f64().unwrap()) / r,
             (l, BigInt(r)) => l / Float(r.to_f64().unwrap()),
             (Float(x), Float(y)) => Float(x / y),
-            (Dec(n), r) => Self::from_dec_str(&n) / r,
-            (l, Dec(n)) => l / Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) / r,
+            (l, Dec(n)) => l / Float(n.num),
         }
     }
 }
@@ -256,8 +296,8 @@ impl core::ops::Rem for Num {
             (BigInt(i), Float(f)) => Float(i.to_f64().unwrap() % f),
             (Float(f), BigInt(i)) => Float(f % i.to_f64().unwrap()),
             (Float(x), Float(y)) => Float(x % y),
-            (Dec(n), r) => Self::from_dec_str(&n) % r,
-            (l, Dec(n)) => l % Self::from_dec_str(&n),
+            (Dec(n), r) => Float(n.num) % r,
+            (l, Dec(n)) => l % Float(n.num),
         }
     }
 }
@@ -269,9 +309,9 @@ impl core::ops::Neg for Num {
             Self::Int(x) => int_or_big(x.checked_neg(), [x], |[x]| -x),
             Self::BigInt(x) => Self::big_int(-&*x),
             Self::Float(x) => Self::Float(-x),
-            Self::Dec(n) => match n.strip_prefix('-') {
-                Some(pos) => Self::Dec(pos.to_string().into()),
-                None => Self::Dec(alloc::format!("-{n}").into()),
+            Self::Dec(n) => match n.lit.strip_prefix('-') {
+                Some(pos) => Self::dec(pos.to_string()),
+                None => Self::dec(alloc::format!("-{n}")),
             },
         }
     }
@@ -292,7 +332,7 @@ impl Hash for Num {
                     f.to_ne_bytes().hash(state);
                 }
             }
-            Self::Dec(d) => Self::from_dec_str(d).hash(state),
+            Self::Dec(d) => Self::Float(d.num).hash(state),
             Self::BigInt(i) => {
                 let f = i.to_f64().unwrap();
                 if f.is_finite() {
@@ -338,8 +378,8 @@ impl PartialEq for Num {
             }
             (Self::Float(x), Self::Float(y)) => float_eq(*x, *y),
             (Self::Dec(x), Self::Dec(y)) if Rc::ptr_eq(x, y) => true,
-            (Self::Dec(n), y) => &Self::from_dec_str(n) == y,
-            (x, Self::Dec(n)) => x == &Self::from_dec_str(n),
+            (Self::Dec(n), y) => &Self::Float(n.num) == y,
+            (x, Self::Dec(n)) => x == &Self::Float(n.num),
         }
     }
 }
@@ -366,8 +406,8 @@ impl Ord for Num {
             (Self::Float(x), Self::BigInt(y)) => float_cmp(*x, y.to_f64().unwrap()),
             (Self::Float(x), Self::Float(y)) => float_cmp(*x, *y),
             (Self::Dec(x), Self::Dec(y)) if Rc::ptr_eq(x, y) => Ordering::Equal,
-            (Self::Dec(n), y) => Self::from_dec_str(n).cmp(y),
-            (x, Self::Dec(n)) => x.cmp(&Self::from_dec_str(n)),
+            (Self::Dec(n), y) => Self::Float(n.num).cmp(y),
+            (x, Self::Dec(n)) => x.cmp(&Self::Float(n.num)),
         }
     }
 }

--- a/jaq-json/src/read.rs
+++ b/jaq-json/src/read.rs
@@ -104,7 +104,7 @@ fn parse_num<L: LexAlloc>(lexer: &mut L) -> Result<Num, hifijson::Error> {
             if parts.is_int() {
                 Num::from_str_radix(num, 10).unwrap()
             } else {
-                Num::Dec(num.to_string().into())
+                Num::dec(num.to_string())
             }
         }
         _ => Err(hifijson::num::Error::ExpectedDigit)?,


### PR DESCRIPTION
Builds on #451 (the first commit here is that PR's commit); please review/merge that one first, after which this PR reduces to its second commit.

Previously, a decimal literal such as `1.5` in a program was stored as a string and re-parsed at every evaluation: first as `isize`, then as big integer, then as `f64`. So `map(. * 1.5)` parsed `"1.5"` once per array element.

Now the compiler stores the parsed `f64` alongside the literal for decimal (non-integer) literals, and the new `ValT::from_dec(lit, num)` method lets jaq-json construct the decimal value directly. The method has a default implementation that falls back to `from_num`, so other value implementations are unaffected. Integer literals that overflow `isize` (which, by the lexer's number grammar, are the only non-decimal literals that reach this path) keep using `from_num`, preserving big integer semantics.

Benchmark (Apple Silicon, release build):

```
map(. * 1.5) over 500k ints    102 ms -> 89 ms
```

The remaining gap to integer constants is the allocation of the literal per produced value, which would need per-run value caching to remove.

Verified identical behaviour against the previous build for literal round-trips (`100.00`, `1.5e3`), big-integer program literals, `0.1 + 0.2`, `1.5 == 1.500`, and out-of-range literals (`1e309`).

Testing: full workspace test suite, `cargo clippy -- -Dwarnings`, `cargo fmt --check`, and MSRV checks with Rust 1.69 (jaq-core) and 1.70 (workspace) all pass.
