### PR TITLE
Fix three arithmetic operations that abort or panic on overflow

### DIFF
--- a/jaq-json/src/lib.rs
+++ b/jaq-json/src/lib.rs
@@ -627,10 +627,10 @@ impl core::ops::Mul for Val {
                 s * Num(Int(bigint_to_int_saturated(&i)))
             }
             (BStr(s), Num(Int(i))) | (Num(Int(i)), BStr(s)) if i > 0 => {
-                Ok(Self::byte_str(s.repeat(i as usize)))
+                Ok(Self::byte_str(repeat_str(&s, i as usize)?))
             }
             (TStr(s), Num(Int(i))) | (Num(Int(i)), TStr(s)) if i > 0 => {
-                Ok(Self::utf8_str(s.repeat(i as usize)))
+                Ok(Self::utf8_str(repeat_str(&s, i as usize)?))
             }
             // string multiplication with negatives or 0 results in null
             // <https://jqlang.github.io/jq/manual/#Builtinoperatorsandfunctions>
@@ -642,6 +642,35 @@ impl core::ops::Mul for Val {
             (l, r) => Err(Error::math(l, ops::Math::Mul, r)),
         }
     }
+}
+
+/// Repeat a byte string `n` times, failing if the result would be too long.
+///
+/// `[u8]::repeat` aborts the process both on a capacity overflow (when
+/// the length exceeds `isize::MAX`, e.g. `"ab" * 9223372036854775807`)
+/// and on allocation failure (when the length is representable but too
+/// large to allocate, e.g. `"a" * 9223372036854775807`). We therefore
+/// bound the length and allocate fallibly, returning an error in both
+/// cases, like jq does.
+fn repeat_str(s: &[u8], n: usize) -> Result<Vec<u8>, Error> {
+    let err = || Error::str("Repeat string result too long");
+    let len = s
+        .len()
+        .checked_mul(n)
+        .filter(|&len| len <= isize::MAX as usize)
+        .ok_or_else(err)?;
+
+    let mut out = Vec::new();
+    out.try_reserve_exact(len).map_err(|_| err())?;
+    if !s.is_empty() {
+        out.extend_from_slice(s);
+        // grow by doubling, so that we copy in O(log n) steps like `repeat`
+        while out.len() < len {
+            let rest = len - out.len();
+            out.extend_from_within(..rest.min(out.len()));
+        }
+    }
+    Ok(out)
 }
 
 /// Split a string by a given separator string.

--- a/jaq-json/src/num.rs
+++ b/jaq-json/src/num.rs
@@ -95,7 +95,9 @@ impl Num {
 
     pub(crate) fn length(&self) -> Self {
         match self {
-            Self::Int(i) => Self::Int(i.abs()),
+            // `i.abs()` would overflow for `isize::MIN`, so fall back to
+            // a big integer in that case, like `Num::neg` does
+            Self::Int(i) => int_or_big(i.checked_abs(), [*i], |[i]| -i),
             Self::BigInt(i) => match i.sign() {
                 Sign::Plus | Sign::NoSign => Self::BigInt(i.clone()),
                 Sign::Minus => Self::BigInt(BigInt::from(i.magnitude().clone()).into()),

--- a/jaq-json/tests/funs.rs
+++ b/jaq-json/tests/funs.rs
@@ -2,7 +2,8 @@
 
 pub mod common;
 
-use common::give;
+use common::{fail, give};
+use jaq_json::Error;
 use serde_json::json;
 
 yields!(bsearch_absent1, "[1, 3] | bsearch(0)", -1);
@@ -174,3 +175,22 @@ yields!(
     r#"("%FF" | @urid) == ([255] | tobytes | tostring)"#,
     true
 );
+
+// `isize::MIN` has no positive `isize` counterpart, so `length`
+// must promote it to a big integer instead of overflowing.
+yields!(
+    length_int_min,
+    "(-9223372036854775807 - 1) | length",
+    9223372036854775808_u64
+);
+
+// multiplying a string by a huge integer must yield an error instead
+// of aborting the process, both when the byte length overflows
+// (`"ab" * isize::MAX`) and when it is representable but too large to
+// allocate (`"a" * isize::MAX`).
+#[test]
+fn mul_str_overflow() {
+    let err = || Error::str("Repeat string result too long");
+    fail(json!(null), r#""ab" * 9223372036854775807"#, err());
+    fail(json!(null), r#""a" * 9223372036854775807"#, err());
+}

--- a/jaq-std/src/time.rs
+++ b/jaq-std/src/time.rs
@@ -5,7 +5,11 @@ use jiff::{civil::DateTime, fmt::strtime, tz, Timestamp};
 /// Convert a UNIX epoch timestamp with optional fractions.
 fn epoch_to_timestamp<V: ValT>(v: &V) -> Result<Timestamp, Error<V>> {
     let val = match v.as_isize() {
-        Some(i) => i as i64 * 1000000,
+        // saturate the multiplication instead of letting it overflow
+        // (which would panic in debug and wrap in release); the
+        // saturated value is out of range for `from_microsecond`,
+        // which then reports the same error as the float path below
+        Some(i) => (i as i64).saturating_mul(1000000),
         None => (v.try_as_f64()? * 1000000.0) as i64,
     };
     Timestamp::from_microsecond(val).map_err(Error::str)

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -43,6 +43,15 @@ yields!(
     "1970-01-02 00:00:00.123456"
 );
 yields!(gmtime, r"86400 | gmtime", [1970, 0, 2, 0, 0, 0, 5, 1]);
+// a huge epoch overflows the microsecond conversion; this must
+// yield an error instead of panicking (debug) or wrapping (release).
+// On success gmtime yields an array, so catching "err" (rather than
+// getting "ok") proves that the error path was taken.
+yields!(
+    gmtime_overflow,
+    r#"100000000000000000 | try (gmtime | "ok") catch "err""#,
+    "err"
+);
 yields!(
     gmtime_mu,
     r"86400.123456 | gmtime",


### PR DESCRIPTION
Three arithmetic edge cases currently abort or panic the process on ordinary filter input. Each is fixed here with a regression test; the fixes are independent commits.

**1. String repetition (`jaq-json`).** `str * n` for a large `n` called `[u8]::repeat`, which aborts the process: `"ab" * 9223372036854775807` aborts with a capacity overflow (the length exceeds `isize::MAX`), and `"a" * 9223372036854775807` aborts with an allocation failure (the length is representable but too large to allocate). Both now bound the length and allocate fallibly with `try_reserve_exact`, returning jq's error `Repeat string result too long`. The non-overflowing path is unchanged in behaviour and stays O(log n) in copies via `extend_from_within`.

**2. `length` of `isize::MIN` (`jaq-json`).** `Num::length` used `i.abs()`, which panics in debug and wraps to a negative length in release for `isize::MIN`. It now promotes to a big integer in that case, mirroring `Num::neg`.

**3. Epoch to timestamp (`jaq-std`).** `epoch_to_timestamp` multiplied the epoch seconds by 1_000_000 without checking for overflow, so a large integer epoch (e.g. `100000000000000000 | gmtime`, also `strftime`/`localtime`) panicked in debug and produced a wrong time in release. It now uses `saturating_mul`, so the value is out of range for `Timestamp::from_microsecond`, which reports the same error jaq already produces for an out-of-range floating-point epoch.

Reproductions (before this PR, release build):

```
$ jaq -n '"ab" * 9223372036854775807'          # capacity overflow, abort
$ jaq -n '"a" * 9223372036854775807'           # allocation failure, abort
$ jaq -n '(-9223372036854775807 - 1) | length' # -9223372036854775808 (release) / panic (debug)
$ jaq -n '100000000000000000 | gmtime'         # panic (debug) / wrong time (release)
```

After this PR, each returns a normal error (or, for `length`, the correct big integer `9223372036854775808`).

Testing: full workspace test suite (including the three new regression tests), `cargo clippy -- -Dwarnings`, `cargo fmt --check`, and MSRV checks with Rust 1.69 (jaq-core) and 1.70 (workspace) all pass.
