### PR TITLE
Limit nesting depth in CBOR and XML readers to prevent stack overflow

### DIFF
--- a/jaq-fmts/src/read/cbor.rs
+++ b/jaq-fmts/src/read/cbor.rs
@@ -34,11 +34,20 @@ const BUF_SIZE: usize = 4096;
 ///
 /// - 16 bytes is the size of a [`jaq_json::Val`] (as should be the case on x86_64),
 /// - 1024 is the maximal capacity that we pre-allocate, and
-/// - 8192 is the maximal stack size.
+/// - 128 is the maximal nesting depth ([`MAX_DEPTH`]).
 ///
 /// Then the maximum amount of memory that can be consumed by such an array is
-/// 16 bytes/value * 1024 values/array * 8192 arrays = 134217728 bytes = 128MB.
+/// 16 bytes/value * 1024 values/array * 128 arrays = 2097152 bytes = 2MB.
+/// (Nested maps can consume twice that amount, because
+/// every map entry holds a key and a value.)
 const MAX_CAP: usize = 1024;
+
+/// Maximal nesting depth of containers (arrays/maps).
+///
+/// Parsing a container recurses, so without this limit,
+/// a small input like `[[[...` (one byte per level) overflows the stack,
+/// aborting the process.
+const MAX_DEPTH: usize = 128;
 
 /// Error that may indicate end of file.
 trait IsEof {
@@ -65,6 +74,8 @@ enum PError<E> {
     Tag(u64),
     /// unexpected break
     Break,
+    /// maximal nesting depth exceeded
+    Depth,
 }
 
 impl<E: fmt::Debug + fmt::Display> std::error::Error for PError<E> {}
@@ -83,6 +94,7 @@ impl<E: fmt::Display> fmt::Display for PError<E> {
             Self::Simple(s) => write!(f, "unsupported simple value: {s}"),
             Self::Tag(t) => write!(f, "unsupported tag: {t}"),
             Self::Break => write!(f, "unexpected break"),
+            Self::Depth => write!(f, "maximal nesting depth ({MAX_DEPTH}) exceeded"),
         }
     }
 }
@@ -115,7 +127,7 @@ where
     core::iter::from_fn(move || {
         let offset = decoder.offset();
         match decoder.pull() {
-            Ok(header) => Some(parse(header, &mut decoder)),
+            Ok(header) => Some(parse(header, &mut decoder, 0)),
             // The following is a hack which is unfortunately necessary because
             // ciborium does not currently give us any means of checking for EOF
             // (<https://github.com/enarx/ciborium/issues/159>).
@@ -194,7 +206,18 @@ fn biguint<R: Read>(decoder: &mut Decoder<R>) -> Result<BigUint, Error<R::Error>
     }
 }
 
-fn parse<R: Read>(header: Header, decoder: &mut Decoder<R>) -> Result<Val, PError<R::Error>> {
+fn parse<R: Read>(
+    header: Header,
+    decoder: &mut Decoder<R>,
+    depth: usize,
+) -> Result<Val, PError<R::Error>> {
+    let deeper = || {
+        if depth < MAX_DEPTH {
+            Ok(depth + 1)
+        } else {
+            Err(PError::Depth)
+        }
+    };
     match header {
         Header::Text(len) => Ok(Val::from(parse_str(len, decoder)?)),
         Header::Bytes(len) => Ok(Val::byte_str(parse_bytes(len, decoder)?)),
@@ -212,12 +235,16 @@ fn parse<R: Read>(header: Header, decoder: &mut Decoder<R>) -> Result<Val, PErro
         Header::Positive(pos) => Ok(Val::Num(Num::from_integral(pos))),
         Header::Negative(neg) => Ok(Val::Num(Num::from_integral(neg as i128 ^ !0))),
         Header::Float(f) => Ok(Val::from(f)),
-        Header::Array(size) => Ok(Val::Arr(
-            with_size(size, decoder, |h, d| parse(h, d))?.into(),
-        )),
+        Header::Array(size) => {
+            let depth = deeper()?;
+            Ok(Val::Arr(
+                with_size(size, decoder, |h, d| parse(h, d, depth))?.into(),
+            ))
+        }
         Header::Map(size) => {
+            let depth = deeper()?;
             let o = with_size(size, decoder, |h, d| {
-                Ok((parse(h, d)?, parse(d.pull()?, d)?))
+                Ok((parse(h, d, depth)?, parse(d.pull()?, d, depth)?))
             })?;
             Ok(Val::obj(o.into_iter().collect()))
         }

--- a/jaq-fmts/src/read/xml.rs
+++ b/jaq-fmts/src/read/xml.rs
@@ -8,8 +8,15 @@ use xmlparser::{ElementEnd, ExternalId, StrSpan, TextPos, Token, Tokenizer};
 /// Parse a stream of root XML values.
 pub fn parse_many(s: &str) -> impl Iterator<Item = Result<Val, Error>> + '_ {
     let mut tokens = Tokenizer::from(s);
-    core::iter::from_fn(move || tokens.next().map(|tk| parse(tk?, &mut tokens)))
+    core::iter::from_fn(move || tokens.next().map(|tk| parse(tk?, &mut tokens, 0)))
 }
+
+/// Maximal nesting depth of elements.
+///
+/// Parsing an element recurses, so without this limit,
+/// a small input like `<a><a><a>...` overflows the stack,
+/// aborting the process.
+const MAX_DEPTH: usize = 128;
 
 /// Prefix and local name of a tag.
 #[derive(Debug)]
@@ -56,6 +63,8 @@ pub enum Error {
     Unmatched(TagPos, TagPos),
     /// Unclosed tag, e.g. `<a>` or `<a`
     Unclosed(TagPos),
+    /// Maximal nesting depth exceeded
+    Depth(TagPos),
 }
 
 impl fmt::Display for Error {
@@ -67,6 +76,9 @@ impl fmt::Display for Error {
             }
             Self::Unclosed(open) => {
                 write!(f, "expected closing tag for {open}, found end of file")
+            }
+            Self::Depth(open) => {
+                write!(f, "maximal nesting depth ({MAX_DEPTH}) exceeded by {open}")
             }
         }
     }
@@ -80,7 +92,7 @@ impl From<xmlparser::Error> for Error {
 
 impl std::error::Error for Error {}
 
-fn parse_children(tag: &Tag, tokens: &mut Tokenizer) -> Result<Vec<Val>, Error> {
+fn parse_children(tag: &Tag, tokens: &mut Tokenizer, depth: usize) -> Result<Vec<Val>, Error> {
     let mut children = Vec::new();
     loop {
         let next = tokens.next();
@@ -96,12 +108,15 @@ fn parse_children(tag: &Tag, tokens: &mut Tokenizer) -> Result<Vec<Val>, Error> 
                     Err(Error::Unmatched(tag.tag_pos(tokens), tag_.tag_pos(tokens)))?
                 }
             }
-            tk => children.push(parse(tk, tokens)?),
+            tk => children.push(parse(tk, tokens, depth)?),
         }
     }
 }
 
-fn tac(tag: &Tag, tokens: &mut Tokenizer) -> Result<Val, Error> {
+fn tac(tag: &Tag, tokens: &mut Tokenizer, depth: usize) -> Result<Val, Error> {
+    if depth > MAX_DEPTH {
+        return Err(Error::Depth(tag.tag_pos(tokens)));
+    }
     let mut attrs = Vec::new();
     let children = loop {
         let next = tokens.next();
@@ -116,7 +131,7 @@ fn tac(tag: &Tag, tokens: &mut Tokenizer) -> Result<Val, Error> {
                 value.as_str().to_owned().into(),
             )),
             Token::ElementEnd { end, .. } => match end {
-                ElementEnd::Open => break Some(parse_children(tag, tokens)?),
+                ElementEnd::Open => break Some(parse_children(tag, tokens, depth)?),
                 ElementEnd::Empty => break None,
                 // SAFETY: xmlparser returns an error instead of yielding this
                 ElementEnd::Close(..) => panic!(),
@@ -153,7 +168,7 @@ fn make_obj<T: Into<Val>, const N: usize>(arr: [(&str, Option<T>); N]) -> Val {
     Val::obj(iter.collect())
 }
 
-fn parse(tk: Token, tokens: &mut Tokenizer) -> Result<Val, Error> {
+fn parse(tk: Token, tokens: &mut Tokenizer, depth: usize) -> Result<Val, Error> {
     let ss_val = |ss: StrSpan| ss.as_str().to_owned().into();
     let singleton = |k: &str, v| Val::obj(core::iter::once((k.to_string().into(), v)).collect());
 
@@ -182,7 +197,7 @@ fn parse(tk: Token, tokens: &mut Tokenizer) -> Result<Val, Error> {
         ),
         Token::Cdata { text, .. } => singleton("cdata", ss_val(text)),
         Token::Comment { text, .. } => singleton("comment", ss_val(text)),
-        Token::ElementStart { prefix, local, .. } => tac(&Tag(prefix, local), tokens)?,
+        Token::ElementStart { prefix, local, .. } => tac(&Tag(prefix, local), tokens, depth + 1)?,
         Token::Text { text } => ss_val(text),
         // SAFETY: xmlparser returns an error instead of yielding this
         Token::Attribute { .. }

--- a/jaq-fmts/src/read/xml.rs
+++ b/jaq-fmts/src/read/xml.rs
@@ -39,7 +39,14 @@ impl fmt::Display for Tag<'_> {
 
 impl Tag<'_> {
     fn tag_pos(&self, tokens: &Tokenizer) -> TagPos {
-        let pos = tokens.stream().gen_text_pos_from(self.0.start());
+        // for tags without prefix, the prefix is an empty span at position 0,
+        // so take the position of the local name instead
+        let start = if self.0.is_empty() {
+            self.1.start()
+        } else {
+            self.0.start()
+        };
+        let pos = tokens.stream().gen_text_pos_from(start);
         TagPos(self.to_string(), pos)
     }
 }

--- a/jaq-fmts/tests/funs.rs
+++ b/jaq-fmts/tests/funs.rs
@@ -26,7 +26,12 @@ yields!(
 );
 yields!(
     fromxml_too_deep,
-    r#""<a>" * 129 | try fromxml catch (contains("maximal nesting depth (128) exceeded by a (at "))"#,
+    r#""<a>" * 129 | try fromxml catch endswith("maximal nesting depth (128) exceeded by a (at 1:386)")"#,
+    true
+);
+yields!(
+    fromxml_unmatched_pos,
+    r#""<r>\n  <a></b></r>" | try fromxml catch endswith("expected closing tag for a (at 2:4), found b (at 2:8)")"#,
     true
 );
 

--- a/jaq-fmts/tests/funs.rs
+++ b/jaq-fmts/tests/funs.rs
@@ -7,6 +7,29 @@ yields!(fromcbor1, "[41] | tobytes | fromcbor", -10);
 yields!(fromcbor2, "[99, 230, 176, 180] | tobytes | fromcbor", "水");
 yields!(tocbor, "-10 | tocbor | . == ([41] | tobytes)", true);
 
+// 129 = 0x81 (array of length 1), 128 = 0x80 (array of length 0)
+yields!(
+    fromcbor_deep,
+    "[limit(127; repeat(129)), 128] | tobytes | fromcbor | getpath([limit(127; repeat(0))])",
+    json!([])
+);
+yields!(
+    fromcbor_too_deep,
+    "[limit(129; repeat(129))] | tobytes | try fromcbor catch endswith(\"maximal nesting depth (128) exceeded\")",
+    true
+);
+
+yields!(
+    fromxml_deep,
+    r#""<a>" * 128 + "x" + "</a>" * 128 | fromxml | getpath([limit(256; repeat("c", 0))])"#,
+    "x"
+);
+yields!(
+    fromxml_too_deep,
+    r#""<a>" * 129 | try fromxml catch (contains("maximal nesting depth (128) exceeded by a (at "))"#,
+    true
+);
+
 // "---" starts a new value, "..." ends a previous value
 yields!(fromyaml_doc1, r#""---\n1" | fromyaml"#, 1);
 yields!(fromyaml_doc2, r#""1\n..." | fromyaml"#, 1);


### PR DESCRIPTION
The CBOR and XML readers parse containers recursively without any depth check, so a small deeply nested input aborts the whole process with a stack overflow:

```
$ python3 -c "import sys; sys.stdout.buffer.write(b'\x81'*100000)" | jaq --from cbor .
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting
$ python3 -c "print('<a>'*200000)" | jaq --from xml .
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

This is also reachable through `fromcbor` / `fromxml` on untrusted strings, where a filter author would reasonably expect a catchable error rather than an abort. (The YAML reader is already safe: saphyr enforces its own nesting limit.)

**First commit**: both readers now track the nesting depth and reject documents nested deeper than 128 containers (the same limit as serde_json) with an ordinary parse error, e.g.

```
$ python3 -c "import sys; sys.stdout.buffer.write(b'\x81'*100000)" | jaq --from cbor .
Error: failed to parse: maximal nesting depth (128) exceeded
```

The choice of 128: debug builds spend several KB of stack per nesting level in the XML reader, and Rust test threads get 2 MB by default (I found that a limit of 1024 overflows there, and 256 fits only barely), so 128 keeps a comfortable margin for debug builds, small thread stacks, and wasm. Real documents nested deeper than 128 levels should be essentially nonexistent. As a side effect, the limit also makes the worst-case pre-allocation bound described at `MAX_CAP` in the CBOR reader actually enforced (previously the "8192 arrays" in that calculation was an assumption without a mechanism).

**Second commit** fixes a papercut that the new error made visible: `Tag::tag_pos` took the error position from the prefix span, which for tags without a namespace prefix is an empty span at position 0, so every error about an unprefixed tag reported `at 1:1` regardless of where the tag was. It now uses the local-name position when the prefix is empty:

```
# before
$ jaq -n '"<r>\n  <a></b></r>" | try fromxml catch .'
"... expected closing tag for a (at 1:1), found b (at 1:1)"
# after
"... expected closing tag for a (at 2:4), found b (at 2:8)"
```

Testing: five new regression tests (nesting at the limit parses, one past the limit errors, for both formats; plus one for the error positions). Full workspace test suite, `cargo clippy -- -Dwarnings`, `cargo fmt --check`, MSRV check with Rust 1.70, and a `jaq-play` check for `wasm32-unknown-unknown` all pass.
