### PR TITLE
Remove `--run-tests` from list of documented flags

### DIFF
--- a/docs/cli.dj
+++ b/docs/cli.dj
@@ -28,7 +28,7 @@ jaq determines the format to parse a _FILE_ as follows:
 
 - If [`--from`](#--from) _FORMAT_ is used, jaq uses that format.
 - Otherwise, if _FILE_ has a file extension known by jaq, such as
-  `.json`, `.yaml`, `.cbor`, `.toml`, `.xml`, `.csv`, `.tsv`
+  `.json`, `.yaml`, `.cbor`, `.toml`, `.xml`, `.csv`, `.tsv`,
   jaq uses the corresponding format.
 - Otherwise, jaq assumes JSON.
 

--- a/jaq/src/help.txt
+++ b/jaq/src/help.txt
@@ -41,3 +41,5 @@ Remaining options:
   -e, --exit-status         Use the last output value as exit status code
   -V, --version             Print version
   -h, --help                Print help
+
+Full documentation: <https://gedenkt.at/jaq/manual/>

--- a/jaq/src/help.txt
+++ b/jaq/src/help.txt
@@ -38,7 +38,6 @@ Variable options:
       --args                Collect remaining positional arguments into `$ARGS.positional`
 
 Remaining options:
-      --run-tests <FILE>    Run tests from a file
   -e, --exit-status         Use the last output value as exit status code
   -V, --version             Print version
   -h, --help                Print help


### PR DESCRIPTION
The test file format is undocumented and for internal use only, so do not expose it in the CLI help.

Also add link to documentation and correct a small typo in the docs.