### PR TITLE
fix(std): make `scan` global by definition, as in jq

### DIFF
--- a/jaq-std/src/defs.jq
+++ b/jaq-std/src/defs.jq
@@ -89,7 +89,7 @@ def flatten($d): if $d > 0 then map(if isarray then flatten($d-1) else [.] end) 
 def capture_of_match: map(select(.name) | { (.name): .string} ) | add + {};
 
 def    test(re; flags): matches(re; flags) | any;
-def    scan(re; flags): matches(re; flags)[] | .[0].string;
+def    scan(re; flags): matches(re; "g" + flags)[] | .[0].string;
 def   match(re; flags): matches(re; flags)[] | .[0] + { captures: .[1:] };
 def capture(re; flags): matches(re; flags)[] | capture_of_match;
 

--- a/jaq-std/tests/defs.rs
+++ b/jaq-std/tests/defs.rs
@@ -79,6 +79,15 @@ yields!(
     ["a", "A", "b", "B"]
 );
 
+// scan is global by definition (jq: `match(re; "g"+flags)`); the author
+// flags ride alongside the forced global.
+yields!(
+    scan_words,
+    r#""one two three" | [scan("\\S+")]"#,
+    ["one", "two", "three"]
+);
+yields!(scan_with_flags, r#""one Two THREE" | [scan("t"; "i")]"#, ["T", "T"]);
+
 #[test]
 fn min_max() {
     give(json!([1, 4, 2]), "min", json!(1));


### PR DESCRIPTION
## Problem

jaq's `scan(re; flags)` (jaq-std 3.0.1 and current `main`) is defined as:

```jq
def scan(re; flags): matches(re; flags)[] | .[0].string;
```

Without the global flag, it yields only the **first** match. jq defines `scan` as global by construction (`match(re; "g"+flags)`), so jaq silently diverges on the exact class `scan` exists for — every number after the first is wrong, with no error anywhere:

```console
$ echo '{"s":"one two three"}' | jaq '[.s | scan("\\S+")]'
["one"]                         # jq 1.7.1: ["one","two","three"]
$ echo '{"s":"one Two THREE"}' | jaq '[.s | scan("t"; "i")]'
["T"]                           # jq 1.7.1: ["T","T"]
```

`match` and `splits` are unaffected (correct with and without `"g"`); the bug is only `scan`'s delegation forgetting the flag.

## Fix

One word, the exact jq construction — author flags ride alongside the forced global:

```jq
def scan(re; flags): matches(re; "g" + flags)[] | .[0].string;
```

After the fix both repro arms print jq's output byte-for-byte.

## Tests

Two `yields!` locks in `jaq-std/tests/defs.rs`: bare `scan` over words and `scan(re; "i")` with author flags. `cargo test --workspace` is green (384 passed).