### PR TITLE
Update to jotdown 0.10.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install jotdown
-      run: cargo install jotdown@0.8.1 --locked
+      run: cargo install jotdown@0.10.0 --features=cli --locked
     - name: Generate documentation and run unit tests
       working-directory: docs
       run: make JAQ=`cargo --quiet --config "target.'cfg(true)'.runner = 'echo'" run`

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -46,7 +46,7 @@ jobs:
       working-directory: jaq-play
 
     - name: Install jotdown
-      run: cargo install jotdown@0.8.1 --locked
+      run: cargo install jotdown@0.10.0 --features=cli --locked
     - name: Generate documentation
       working-directory: docs
       run: make JAQ="cargo run --" MANUAL.xhtml

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ allows for much faster parsing than Markdown.
 This requires `jotdown`. To install it:
 
 ```
-cargo install jotdown@0.8.1 --locked
+cargo install jotdown@0.10.0 --features=cli --locked
 ```
 
 To generate HTML and man versions of the manual, run `make -j`.


### PR DESCRIPTION
This corrects the HTML output in exactly one place, namely the starting quote in “Select Graphic Rendition”.