### PR TITLE
Bump `jaq-std`'s minor version to account for new `std` feature dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 
 [workspace.dependencies]
 jaq-core = { version = "3.1.0", path = "jaq-core", default-features = false }
-jaq-std  = { version = "3.0.1", path = "jaq-std" , default-features = false }
+jaq-std  = { version = "3.0.2", path = "jaq-std" , default-features = false }
 jaq-json = { version = "2.0.2", path = "jaq-json", default-features = false }
 jaq-fmts = { version = "0.1.1", path = "jaq-fmts", default-features = false }
 jaq-all  = { version = "0.3.0", path = "jaq-all" , default-features = false }

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jaq-std"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Michael Färber <michael.faerber@gedenkt.at>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Addresses #461.