### PR TITLE
Make `no_std` work

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Install a `no_std` Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        target: thumbv7em-none-eabihf
+
     - uses: actions/cache/restore@v5
       with:
         path: |
@@ -30,15 +35,15 @@ jobs:
 
     - name: Check jaq-core without default features
       working-directory: jaq-core
-      run: cargo check --no-default-features
+      run: cargo check --target thumbv7em-none-eabihf --no-default-features
 
     - name: Check jaq-std without default features
       working-directory: jaq-std
-      run: cargo check --no-default-features
+      run: cargo check --target thumbv7em-none-eabihf --no-default-features
 
     - name: Check jaq-json without default features
       working-directory: jaq-json
-      run: cargo check --no-default-features
+      run: cargo check --target thumbv7em-none-eabihf --no-default-features
 
     - name: Check jaq-core fuzzing target compilation
       working-directory: jaq-core/fuzz

--- a/jaq-core/Cargo.toml
+++ b/jaq-core/Cargo.toml
@@ -18,8 +18,8 @@ std = []
 [dependencies]
 arbitrary = { version = "1.4", optional = true }
 dyn-clone = "1.0"
-once_cell = "1.16.0"
-typed-arena = "2.0.2"
+once_cell = { version = "1.16.0", default-features = false }
+typed-arena = { version = "2.0.2", default-features = false }
 
 [dev-dependencies]
 jaq-std  = { path = "../jaq-std" }

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["serde_core"]
 jaq-core = { workspace = true }
 jaq-std  = { workspace = true }
 
-bstr = { version = "1", default-features = false, features = ["alloc"] }
+bstr = { version = "1.6", default-features = false, features = ["alloc", "unicode"] }
 bytes = { version = "1", default-features = false }
 foldhash = { version = "0.1", default-features = false }
 hifijson = { version = "0.5.0", default-features = false, features = ["alloc"] }

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -21,8 +21,8 @@ serde = ["serde_core"]
 jaq-core = { workspace = true }
 jaq-std  = { workspace = true }
 
-bstr = "1"
-bytes = "1"
+bstr = { version = "1", default-features = false, features = ["alloc"] }
+bytes = { version = "1", default-features = false }
 foldhash = { version = "0.1", default-features = false }
 hifijson = { version = "0.5.0", default-features = false, features = ["alloc"] }
 indexmap = { version = "2.0", default-features = false }

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["serde_core"]
 jaq-core = { workspace = true }
 jaq-std  = { workspace = true }
 
-bstr = { version = "1.6", default-features = false, features = ["alloc", "unicode"] }
+bstr = { version = "1", default-features = false }
 bytes = { version = "1", default-features = false }
 foldhash = { version = "0.1", default-features = false }
 hifijson = { version = "0.5.0", default-features = false, features = ["alloc"] }

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -21,7 +21,7 @@ time = ["jiff"]
 [dependencies]
 jaq-core = { workspace = true }
 
-bstr = "1"
+bstr = { version = "1", default-features = false, features = ["alloc"] }
 jiff = { version = "0.2.15", optional = true }
 regex-bites = { version = "0.1", optional = true }
 log = { version = "0.4.17", optional = true }

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -21,7 +21,7 @@ time = ["jiff"]
 [dependencies]
 jaq-core = { workspace = true }
 
-bstr = { version = "1", default-features = false, features = ["alloc"] }
+bstr = { version = "1.6", default-features = false, features = ["alloc", "unicode"] }
 jiff = { version = "0.2.15", optional = true }
 regex-bites = { version = "0.1", optional = true }
 log = { version = "0.4.17", optional = true }

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -537,13 +537,13 @@ where
             unary(cv, |v, suf| v.strip_fix(&suf, <[u8]>::strip_suffix))
         }),
         ("trim", v(0), |cv| {
-            bome(cv.1.trim_utf8_with(|s| s.trim_with(char::is_whitespace)))
+            bome(cv.1.trim_utf8_with(ByteSlice::trim))
         }),
         ("ltrim", v(0), |cv| {
-            bome(cv.1.trim_utf8_with(|s| s.trim_start_with(char::is_whitespace)))
+            bome(cv.1.trim_utf8_with(ByteSlice::trim_start))
         }),
         ("rtrim", v(0), |cv| {
-            bome(cv.1.trim_utf8_with(|s| s.trim_end_with(char::is_whitespace)))
+            bome(cv.1.trim_utf8_with(ByteSlice::trim_end))
         }),
         ("escape_sh", v(0), |cv| {
             bome(

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -25,12 +25,21 @@ mod regex;
 #[cfg(feature = "time")]
 mod time;
 
-use alloc::string::{String, ToString};
+#[cfg(feature = "std")]
+use alloc::string::String;
+#[cfg(feature = "format")]
+use alloc::string::ToString;
 use alloc::{boxed::Box, vec::Vec};
-use bstr::{BStr, ByteSlice};
+#[cfg(feature = "log")]
+use bstr::BStr;
+use bstr::ByteSlice;
 use jaq_core::box_iter::{box_once, BoxIter};
 use jaq_core::native::{bome, run, unary, v, Filter, Fun};
-use jaq_core::{load, Bind, Cv, DataT, Error, Exn, RunPtr, ValR, ValT as _, ValX, ValXs};
+#[cfg(feature = "regex")]
+use jaq_core::Cv;
+#[cfg(any(feature = "regex", feature = "std"))]
+use jaq_core::ValT as _;
+use jaq_core::{load, Bind, DataT, Error, Exn, RunPtr, ValR, ValX, ValXs};
 
 /// Definitions of the standard library.
 pub fn defs() -> impl Iterator<Item = load::parse::Def<&'static str>> {
@@ -201,6 +210,7 @@ trait ValTx: ValT + Sized {
 
     /// If the value is interpreted as UTF-8 string,
     /// return its `str` representation.
+    #[cfg(any(feature = "regex", feature = "time"))]
     fn try_as_str(&self) -> Result<&str, Error<Self>> {
         self.try_as_utf8_bytes()
             .and_then(|s| core::str::from_utf8(s).map_err(Error::str))

--- a/jaq-std/src/lib.rs
+++ b/jaq-std/src/lib.rs
@@ -361,6 +361,117 @@ fn once_or_empty<'a, T: 'a, E: 'a>(r: Result<Option<T>, E>) -> BoxIter<'a, Resul
     Box::new(r.transpose().into_iter())
 }
 
+// Primitive float rounding methods are unavailable without `std`.
+// These can be dropped after `core_float_math` lands: https://github.com/rust-lang/rust/issues/137578
+fn floor(x: f64) -> f64 {
+    #[cfg(feature = "std")]
+    return x.floor();
+    #[cfg(not(feature = "std"))]
+    return no_std_float::floor(x);
+}
+
+fn round(x: f64) -> f64 {
+    #[cfg(feature = "std")]
+    return x.round();
+    #[cfg(not(feature = "std"))]
+    return no_std_float::round(x);
+}
+
+fn ceil(x: f64) -> f64 {
+    #[cfg(feature = "std")]
+    return x.ceil();
+    #[cfg(not(feature = "std"))]
+    return no_std_float::ceil(x);
+}
+
+#[cfg(any(not(feature = "std"), test))]
+mod no_std_float {
+    const SIGN_MASK: u64 = 1 << 63;
+    const SIG_BITS: i32 = 52;
+    const SIG_MASK: u64 = (1 << SIG_BITS) - 1;
+    const EXPONENT_BIAS: i32 = 1023;
+
+    // Adapted from Rust's MIT-licensed `libm` implementation:
+    // https://github.com/rust-lang/compiler-builtins/blob/5c5f07851b1878013ac81e129b0517feaaf8661d/libm/src/math/generic/trunc.rs
+    fn trunc(x: f64) -> f64 {
+        let xi = x.to_bits();
+        let e = ((xi >> SIG_BITS) & 0x7ff) as i32 - EXPONENT_BIAS;
+        if e >= SIG_BITS {
+            return x;
+        }
+        let clear_mask = if e < 0 { !SIGN_MASK } else { SIG_MASK >> e };
+        let cleared = xi & clear_mask;
+        f64::from_bits(xi ^ cleared)
+    }
+
+    pub fn floor(x: f64) -> f64 {
+        let trunc = trunc(x);
+        if x < trunc {
+            trunc - 1.0
+        } else {
+            trunc
+        }
+    }
+
+    pub fn round(x: f64) -> f64 {
+        let trunc = trunc(x);
+        let fract = x - trunc;
+        if fract >= 0.5 {
+            trunc + 1.0
+        } else if fract <= -0.5 {
+            trunc - 1.0
+        } else {
+            trunc
+        }
+    }
+
+    pub fn ceil(x: f64) -> f64 {
+        let trunc = trunc(x);
+        if x > trunc {
+            trunc + 1.0
+        } else {
+            trunc
+        }
+    }
+
+    #[cfg(all(test, feature = "std"))]
+    mod tests {
+        #[track_caller]
+        fn assert_same(actual: f64, expected: f64) {
+            if expected.is_nan() {
+                assert!(actual.is_nan());
+            } else {
+                assert_eq!(actual.to_bits(), expected.to_bits());
+            }
+        }
+
+        #[test]
+        fn matches_std() {
+            let values = [
+                f64::NEG_INFINITY,
+                -((1_u64 << 53) as f64),
+                -1.5,
+                -0.5,
+                -f64::from_bits(1),
+                -0.0,
+                0.0,
+                f64::from_bits(1),
+                0.5,
+                1.5,
+                (1_u64 << 53) as f64,
+                f64::INFINITY,
+                f64::NAN,
+            ];
+            for x in values {
+                assert_same(super::trunc(x), x.trunc());
+                assert_same(super::floor(x), x.floor());
+                assert_same(super::round(x), x.round());
+                assert_same(super::ceil(x), x.ceil());
+            }
+        }
+    }
+}
+
 #[allow(clippy::unit_arg)]
 fn base_run<D: DataT>() -> Box<[Filter<RunPtr<D>>]>
 where
@@ -368,9 +479,9 @@ where
 {
     let f = || [Bind::Fun(())].into();
     Box::new([
-        ("floor", v(0), |cv| bome(cv.1.round(f64::floor))),
-        ("round", v(0), |cv| bome(cv.1.round(f64::round))),
-        ("ceil", v(0), |cv| bome(cv.1.round(f64::ceil))),
+        ("floor", v(0), |cv| bome(cv.1.round(floor))),
+        ("round", v(0), |cv| bome(cv.1.round(round))),
+        ("ceil", v(0), |cv| bome(cv.1.round(ceil))),
         ("utf8bytelength", v(0), |cv| {
             bome(cv.1.try_as_utf8_bytes().map(|s| (s.len() as isize).into()))
         }),
@@ -426,13 +537,13 @@ where
             unary(cv, |v, suf| v.strip_fix(&suf, <[u8]>::strip_suffix))
         }),
         ("trim", v(0), |cv| {
-            bome(cv.1.trim_utf8_with(ByteSlice::trim))
+            bome(cv.1.trim_utf8_with(|s| s.trim_with(char::is_whitespace)))
         }),
         ("ltrim", v(0), |cv| {
-            bome(cv.1.trim_utf8_with(ByteSlice::trim_start))
+            bome(cv.1.trim_utf8_with(|s| s.trim_start_with(char::is_whitespace)))
         }),
         ("rtrim", v(0), |cv| {
-            bome(cv.1.trim_utf8_with(ByteSlice::trim_end))
+            bome(cv.1.trim_utf8_with(|s| s.trim_end_with(char::is_whitespace)))
         }),
         ("escape_sh", v(0), |cv| {
             bome(

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -254,6 +254,7 @@ fn trim() {
     give(json!(" foo  "), "trim", json!("foo"));
     give(json!("  foo  "), "trim", json!("foo"));
     give(json!("foo  "), "trim", json!("foo"));
+    give(json!("\u{2003}foo\u{2003}"), "trim", json!("foo"));
     give(json!(" اَلْعَرَبِيَّةُ "), "trim", json!("اَلْعَرَبِيَّةُ"));
 }
 
@@ -266,6 +267,7 @@ fn ltrim() {
     give(json!(" foo  "), "ltrim", json!("foo  "));
     give(json!("  foo  "), "ltrim", json!("foo  "));
     give(json!("foo  "), "ltrim", json!("foo  "));
+    give(json!("\u{2003}foo\u{2003}"), "ltrim", json!("foo\u{2003}"));
     give(json!(" اَلْعَرَبِيَّةُ "), "ltrim", json!("اَلْعَرَبِيَّةُ "));
 }
 
@@ -278,5 +280,6 @@ fn rtrim() {
     give(json!("  foo "), "rtrim", json!("  foo"));
     give(json!("  foo  "), "rtrim", json!("  foo"));
     give(json!("  foo"), "rtrim", json!("  foo"));
+    give(json!("\u{2003}foo\u{2003}"), "rtrim", json!("\u{2003}foo"));
     give(json!(" اَلْعَرَبِيَّةُ "), "rtrim", json!(" اَلْعَرَبِيَّةُ"));
 }

--- a/jaq-std/tests/funs.rs
+++ b/jaq-std/tests/funs.rs
@@ -254,7 +254,6 @@ fn trim() {
     give(json!(" foo  "), "trim", json!("foo"));
     give(json!("  foo  "), "trim", json!("foo"));
     give(json!("foo  "), "trim", json!("foo"));
-    give(json!("\u{2003}foo\u{2003}"), "trim", json!("foo"));
     give(json!(" اَلْعَرَبِيَّةُ "), "trim", json!("اَلْعَرَبِيَّةُ"));
 }
 
@@ -267,7 +266,6 @@ fn ltrim() {
     give(json!(" foo  "), "ltrim", json!("foo  "));
     give(json!("  foo  "), "ltrim", json!("foo  "));
     give(json!("foo  "), "ltrim", json!("foo  "));
-    give(json!("\u{2003}foo\u{2003}"), "ltrim", json!("foo\u{2003}"));
     give(json!(" اَلْعَرَبِيَّةُ "), "ltrim", json!("اَلْعَرَبِيَّةُ "));
 }
 
@@ -280,6 +278,5 @@ fn rtrim() {
     give(json!("  foo "), "rtrim", json!("  foo"));
     give(json!("  foo  "), "rtrim", json!("  foo"));
     give(json!("  foo"), "rtrim", json!("  foo"));
-    give(json!("\u{2003}foo\u{2003}"), "rtrim", json!("\u{2003}foo"));
     give(json!(" اَلْعَرَبِيَّةُ "), "rtrim", json!(" اَلْعَرَبِيَّةُ"));
 }


### PR DESCRIPTION
First of all, thanks a lot for this wonderful family of libraries!

Tried to use jaq in a `no_std` context and failed (std was pulled in through dependencies), this is my attempt to make it work.

- `thumbv7em-none-eabihf` in CI is to exercise in a real `no_std` environment
- `floor`, `round` and `ceil` reimplementations to avoid an unconditional `libm` dependency (waiting for https://github.com/rust-lang/rust/issues/137578 to land!)

### Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).