### PR TITLE
Bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "jaq-core"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "arbitrary",
  "dyn-clone",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "bstr",
  "bytes",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-jaq-core = { version = "3.1.0", path = "jaq-core", default-features = false }
-jaq-std  = { version = "3.0.2", path = "jaq-std" , default-features = false }
-jaq-json = { version = "2.0.2", path = "jaq-json", default-features = false }
+jaq-core = { version = "3.1.1", path = "jaq-core", default-features = false }
+jaq-std  = { version = "3.0.3", path = "jaq-std" , default-features = false }
+jaq-json = { version = "2.0.3", path = "jaq-json", default-features = false }
 jaq-fmts = { version = "0.1.1", path = "jaq-fmts", default-features = false }
 jaq-all  = { version = "0.3.0", path = "jaq-all" , default-features = false }
 

--- a/jaq-core/Cargo.toml
+++ b/jaq-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jaq-core"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Michael Färber <michael.faerber@gedenkt.at>"]
 edition = "2021"
 license = "MIT"

--- a/jaq-json/Cargo.toml
+++ b/jaq-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jaq-json"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Michael Färber <michael.faerber@gedenkt.at>"]
 edition = "2021"
 license = "MIT"

--- a/jaq-std/Cargo.toml
+++ b/jaq-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jaq-std"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Michael Färber <michael.faerber@gedenkt.at>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
This is only a minor release of some crates with no impact on end users of the jaq CLI. Its main addition is proper `no_std` support, see #464 by @flyingmutant.